### PR TITLE
Untitled

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -1,8 +1,8 @@
 module Paranoia
   def destroy
-    self[:deleted_at] ||= Time.now
-    self.save
     _run_destroy_callbacks
+    self[:deleted_at] ||= Time.now
+    self.save    
   end
   alias :delete :destroy
 


### PR DESCRIPTION
Hey guys, I started having some issues with paranoia + dependent destroys and the culprit was the order in which the deleted_at attribute gets updated. I switched those around and it now behaves as expected in those scenarios.

Cheers,
