### PR TITLE
Preserve ActiveRecord semantics / Don't require models to be valid before destroy or delete.

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -10,8 +10,10 @@ module Paranoia
   def destroy
     _run_destroy_callbacks
     self[:deleted_at] ||= Time.now
-    self.save(:validate => false)
-    self.freeze
+    # If the instance has already been persisted, then we need to re-save it to flag it as
+    # destroyed / deleted.  We don't require validation in case it causes the updated to fail.
+    save(:validate => false) if persisted?
+    freeze
   end
   alias :delete :destroy
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -10,7 +10,7 @@ module Paranoia
   def destroy
     _run_destroy_callbacks
     self[:deleted_at] ||= Time.now
-    self.save    
+    self.save(:validate => false)
   end
   alias :delete :destroy
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -11,6 +11,7 @@ module Paranoia
     _run_destroy_callbacks
     self[:deleted_at] ||= Time.now
     self.save(:validate => false)
+    self.freeze
   end
   alias :delete :destroy
 


### PR DESCRIPTION
Hi Radar,

Thanks for re-implementing a very useful plugin.

I've forked it to add some tweaks.  I noticed that trying to destroy / delete an invalid model failed.  Since we are blowing away the mode, I think it's better that this not be a restriction, so I've changed the implementation to skip validations on save.

Also, the original AR implementations return a frozen instance of the destroyed / deleted model instance. I've re-instated this behaviour in my fork.

Regards,

Tony.
