### PR TITLE
Preserve ActiveRecord semantics / Don't require models to be valid before destroy or delete.

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -9,11 +9,7 @@ module Paranoia
 
   def destroy
     _run_destroy_callbacks
-    self[:deleted_at] ||= Time.now
-    # If the instance has already been persisted, then we need to re-save it to flag it as
-    # destroyed / deleted.  We don't require validation in case it causes the updated to fail.
-    save(:validate => false) if persisted?
-    freeze
+    self.update_attribute(:deleted_at, Time.now) if !deleted? && persisted?
   end
   alias :delete :destroy
 

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -15,8 +15,11 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "paranoia"
   
   s.add_dependency "activerecord", ">= 3.0.0"
+  #s.add_dependency "activerecord", ">= 3.1.0.rc1"
 
   s.add_development_dependency "bundler", ">= 1.0.0"
+  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "rake", "0.8.7"
   
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -1,6 +1,6 @@
 require 'test/unit'
 require 'active_record'
-require 'lib/paranoia'
+require 'paranoia'
 
 DB_FILE = 'tmp/test_db'
 
@@ -8,8 +8,9 @@ FileUtils.mkdir_p File.dirname(DB_FILE)
 FileUtils.rm_f DB_FILE
 
 ActiveRecord::Base.establish_connection :adapter => 'sqlite3', :database => DB_FILE
-ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_models (id INTEGER NOT NULL PRIMARY KEY)'
-ActiveRecord::Base.connection.execute 'CREATE TABLE plain_models (id INTEGER NOT NULL PRIMARY KEY)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE featureful_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME, name VARCHAR(32))'
+ActiveRecord::Base.connection.execute 'CREATE TABLE plain_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 
 class ParanoiaTest < Test::Unit::TestCase
   def test_plain_model_class_is_not_paranoid
@@ -28,12 +29,61 @@ class ParanoiaTest < Test::Unit::TestCase
     assert_equal true, ParanoidModel.new.paranoid?
   end
 
+  def test_delete_behavior_for_plain_models
+    model = PlainModel.new
+    assert_equal 0, model.class.count
+    model.save!
+    assert_equal 1, model.class.count
+    model.delete
+
+    assert_equal true, model.deleted_at.nil?
+    
+    assert_equal 0, model.class.count
+    assert_equal 0, model.class.unscoped.count
+  end
+
+  def test_delete_behavior_for_paranoid_models
+    model = ParanoidModel.new
+    assert_equal 0, model.class.count
+    model.save!
+    assert_equal 1, model.class.count
+    model.delete
+
+    assert_equal false, model.deleted_at.nil?
+
+    assert_equal 0, model.class.count
+    assert_equal 1, model.class.unscoped.count
+
+  end
+
+  def test_delete_behavior_for_featureful_paranoid_models
+    model = get_featureful_model
+    assert_equal 0, model.class.count
+    model.save!
+    assert_equal 1, model.class.count
+    model.delete
+
+    assert_equal false, model.deleted_at.nil?
+    
+    assert_equal 0, model.class.count
+    assert_equal 1, model.class.unscoped.count
+  end
+
+  private
+  def get_featureful_model
+    FeaturefulModel.new(:name => "not empty")
+  end
 end
 
 # Helper classes
 
 class ParanoidModel < ActiveRecord::Base
   acts_as_paranoid
+end
+
+class FeaturefulModel < ActiveRecord::Base
+  acts_as_paranoid
+  validates :name, :presence => true, :uniqueness => true
 end
 
 class PlainModel < ActiveRecord::Base


### PR DESCRIPTION
Hi Radar,

the in Issue #7 proposed (and pulled) changes don't fix the problem for me. I've extended the tests to provoke the problem (see fb9c903a8ff0097359cda631a410d867ae606aef).
For me c14aa4b6bd356ffe1cae48aee50b1f4c5e3f983c fixes those problems, so give it a try :-)

greetings
leh
