### PR TITLE
Deletion and Restoration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,6 @@ Bundler::GemHelper.install_tasks
 
 task :test do
   Dir['test/*_test.rb'].each do |testfile|
-      load testfile
+    load testfile
   end
 end

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -14,14 +14,20 @@ module Paranoia
   end
 
   def destroy
-    _run_destroy_callbacks
+    _run_destroy_callbacks { delete }
+  end
+
+  def delete    
     self.update_attribute(:deleted_at, Time.now) if !deleted? && persisted?
     freeze
   end
-  alias :delete :destroy
+  
+  def restore!
+    update_attribute :deleted_at, nil
+  end
 
   def destroyed?
-    !self[:deleted_at].nil?
+    !self.deleted_at.nil?
   end
   alias :deleted? :destroyed?
 end

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -34,7 +34,9 @@ end
 
 class ActiveRecord::Base
   def self.acts_as_paranoid
-    self.send(:include, Paranoia)
+    alias_method :destroy!, :destroy
+    alias_method :delete!,  :delete
+    include Paranoia
     default_scope :conditions => { :deleted_at => nil }
   end
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -113,6 +113,22 @@ class ParanoiaTest < Test::Unit::TestCase
     
     assert_equal false, model.destroyed?
   end
+  
+  def test_real_destroy
+    model = ParanoidModel.new
+    model.save
+    model.destroy!
+    
+    assert_equal false, ParanoidModel.unscoped.exists?(model.id)
+  end
+  
+  def test_real_delete
+    model = ParanoidModel.new
+    model.save
+    model.delete!
+    
+    assert_equal false, ParanoidModel.unscoped.exists?(model.id)
+  end
 
   private
   def get_featureful_model

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -11,6 +11,7 @@ ActiveRecord::Base.establish_connection :adapter => 'sqlite3', :database => DB_F
 ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE featureful_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME, name VARCHAR(32))'
 ActiveRecord::Base.connection.execute 'CREATE TABLE plain_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE callback_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 
 class ParanoiaTest < Test::Unit::TestCase
   def test_plain_model_class_is_not_paranoid
@@ -29,12 +30,12 @@ class ParanoiaTest < Test::Unit::TestCase
     assert_equal true, ParanoidModel.new.paranoid?
   end
 
-  def test_delete_behavior_for_plain_models
+  def test_destroy_behavior_for_plain_models
     model = PlainModel.new
     assert_equal 0, model.class.count
     model.save!
     assert_equal 1, model.class.count
-    model.delete
+    model.destroy
 
     assert_equal true, model.deleted_at.nil?
     assert model.frozen?
@@ -43,12 +44,12 @@ class ParanoiaTest < Test::Unit::TestCase
     assert_equal 0, model.class.unscoped.count
   end
 
-  def test_delete_behavior_for_paranoid_models
+  def test_destroy_behavior_for_paranoid_models
     model = ParanoidModel.new
     assert_equal 0, model.class.count
     model.save!
     assert_equal 1, model.class.count
-    model.delete
+    model.destroy
 
     assert_equal false, model.deleted_at.nil?
     assert model.frozen?
@@ -58,12 +59,12 @@ class ParanoiaTest < Test::Unit::TestCase
 
   end
 
-  def test_delete_behavior_for_featureful_paranoid_models
+  def test_destroy_behavior_for_featureful_paranoid_models
     model = get_featureful_model
     assert_equal 0, model.class.count
     model.save!
     assert_equal 1, model.class.count
-    model.delete
+    model.destroy
 
     assert_equal false, model.deleted_at.nil?
 
@@ -71,15 +72,46 @@ class ParanoiaTest < Test::Unit::TestCase
     assert_equal 1, model.class.unscoped.count
   end
 
-  def test_only_deleted_scope_for_paranoid_models
+  def test_only_destroyed_scope_for_paranoid_models
     model = ParanoidModel.new
     model.save
-    model.delete
+    model.destroy
     model2 = ParanoidModel.new
     model2.save
 
     assert_equal model, ParanoidModel.only_deleted.last
     assert_equal false, ParanoidModel.only_deleted.include?(model2)
+  end
+  
+  def test_delete_behavior_for_callbacks
+    model = CallbackModel.new
+    model.save
+    model.delete
+    assert_equal nil, model.instance_variable_get(:@callback_called)
+  end
+  
+  def test_destroy_behavior_for_callbacks
+    model = CallbackModel.new
+    model.save
+    model.destroy
+    assert model.instance_variable_get(:@callback_called)
+  end
+  
+  def test_restore
+    model = ParanoidModel.new
+    model.save
+    id = model.id
+    model.destroy
+    
+    puts model.inspect
+    puts ParanoidModel.all.inspect
+    
+    assert model.destroyed?
+    
+    model = ParanoidModel.only_deleted.find(id)
+    model.restore!
+    
+    assert_equal false, model.destroyed?
   end
 
   private
@@ -100,4 +132,9 @@ class FeaturefulModel < ActiveRecord::Base
 end
 
 class PlainModel < ActiveRecord::Base
+end
+
+class CallbackModel < ActiveRecord::Base
+  acts_as_paranoid
+  before_destroy {|model| model.instance_variable_set :@callback_called, true }
 end


### PR DESCRIPTION
`delete` is now a separate action from `destroy`. It skips callbacks and validations and whatnot, whereas `destroy` does not.

I also added `restore`, which silently updates `deleted_at` to be nil. It does _not_ unfreeze the attributes hash.

I added tests for all of this stuff.
