### PR TITLE
Add test coverage for has_many and has_many :through behavior.

### DIFF
--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -12,6 +12,11 @@ ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_models (id INTEGER 
 ActiveRecord::Base.connection.execute 'CREATE TABLE featureful_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME, name VARCHAR(32))'
 ActiveRecord::Base.connection.execute 'CREATE TABLE plain_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE callback_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE parent_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE related_models (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER NOT NULL, deleted_at DATETIME)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE employers (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE employees (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE jobs (id INTEGER NOT NULL PRIMARY KEY, employer_id INTEGER NOT NULL, employee_id INTEGER NOT NULL, deleted_at DATETIME)'
 
 class ParanoiaTest < Test::Unit::TestCase
   def test_plain_model_class_is_not_paranoid
@@ -67,7 +72,6 @@ class ParanoiaTest < Test::Unit::TestCase
 
     assert_equal 0, model.class.count
     assert_equal 1, model.class.unscoped.count
-
   end
 
   def test_destroy_behavior_for_featureful_paranoid_models
@@ -93,48 +97,89 @@ class ParanoiaTest < Test::Unit::TestCase
     assert_equal model, ParanoidModel.only_deleted.last
     assert_equal false, ParanoidModel.only_deleted.include?(model2)
   end
-  
+
+  def test_default_scope_for_has_many_relationships
+    parent = ParentModel.create
+    assert_equal 0, parent.related_models.count
+
+    child = parent.related_models.create
+    assert_equal 1, parent.related_models.count
+
+    child.destroy
+    assert_equal false, child.deleted_at.nil?
+
+    assert_equal 0, parent.related_models.count
+    assert_equal 1, parent.related_models.unscoped.count
+  end
+
+  def test_default_scope_for_has_many_through_relationships
+    employer = Employer.create
+    employee = Employee.create
+    assert_equal 0, employer.jobs.count
+    assert_equal 0, employer.employees.count
+    assert_equal 0, employee.jobs.count
+    assert_equal 0, employee.employers.count
+
+    job = Job.create :employer => employer, :employee => employee
+    assert_equal 1, employer.jobs.count
+    assert_equal 1, employer.employees.count
+    assert_equal 1, employee.jobs.count
+    assert_equal 1, employee.employers.count
+
+    employee2 = Employee.create
+    job2 = Job.create :employer => employer, :employee => employee2
+    employee2.destroy
+    assert_equal 2, employer.jobs.count
+    assert_equal 1, employer.employees.count
+
+    job.destroy
+    assert_equal 1, employer.jobs.count
+    assert_equal 0, employer.employees.count
+    assert_equal 0, employee.jobs.count
+    assert_equal 0, employee.employers.count
+  end
+
   def test_delete_behavior_for_callbacks
     model = CallbackModel.new
     model.save
     model.delete
     assert_equal nil, model.instance_variable_get(:@callback_called)
   end
-  
+
   def test_destroy_behavior_for_callbacks
     model = CallbackModel.new
     model.save
     model.destroy
     assert model.instance_variable_get(:@callback_called)
   end
-  
+
   def test_restore
     model = ParanoidModel.new
     model.save
     id = model.id
     model.destroy
-    
+
     assert model.destroyed?
-    
+
     model = ParanoidModel.only_deleted.find(id)
     model.restore!
-    
+
     assert_equal false, model.destroyed?
   end
-  
+
   def test_real_destroy
     model = ParanoidModel.new
     model.save
     model.destroy!
-    
+
     assert_equal false, ParanoidModel.unscoped.exists?(model.id)
   end
-  
+
   def test_real_delete
     model = ParanoidModel.new
     model.save
     model.delete!
-    
+
     assert_equal false, ParanoidModel.unscoped.exists?(model.id)
   end
 
@@ -161,4 +206,32 @@ end
 class CallbackModel < ActiveRecord::Base
   acts_as_paranoid
   before_destroy {|model| model.instance_variable_set :@callback_called, true }
+end
+
+class ParentModel < ActiveRecord::Base
+  acts_as_paranoid
+  has_many :related_models
+end
+
+class RelatedModel < ActiveRecord::Base
+  acts_as_paranoid
+  belongs_to :parent_model
+end
+
+class Employer < ActiveRecord::Base
+  acts_as_paranoid
+  has_many :jobs
+  has_many :employees, :through => :jobs
+end
+
+class Employee < ActiveRecord::Base
+  acts_as_paranoid
+  has_many :jobs
+  has_many :employers, :through => :jobs
+end
+
+class Job < ActiveRecord::Base
+  acts_as_paranoid
+  belongs_to :employer
+  belongs_to :employee
 end


### PR DESCRIPTION
Issue #6 talks about `has_many :through` relationships not respecting the default scope when the join model is deleted.  Unless I missed something these specs cover that scenario and verify the gem acts as expected.
