### PR TITLE
Update_attribute is gone in Rails 4, add update_column support.

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -17,19 +17,26 @@ module Paranoia
     _run_destroy_callbacks { delete }
   end
 
-  def delete    
-    self.update_attribute(:deleted_at, Time.now) if !deleted? && persisted?
+  def delete
+    update_attribute_or_column(:deleted_at, Time.now) if !deleted? && persisted?
     freeze
   end
-  
+
   def restore!
-    update_attribute :deleted_at, nil
+    update_attribute_or_column :deleted_at, nil
   end
 
   def destroyed?
     !self.deleted_at.nil?
   end
   alias :deleted? :destroyed?
+
+  private
+
+  # Rails 3.1 adds update_column. Rails > 3.2.6 deprecates update_attribute, gone in Rails 4.
+  def update_attribute_or_column(*args)
+    respond_to?(:update_column) ? update_column(*args) : update_attribute(*args)
+  end
 end
 
 class ActiveRecord::Base


### PR DESCRIPTION
update_attribute is deprecated in Rails > 3.2.6. Use update_column if available.
