### PR TITLE
Fix for ambiguous column 'deleted_at' issue

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -8,7 +8,7 @@ module Paranoia
 
     def only_deleted
       unscoped {
-        where("deleted_at is not null")
+        where("#{self.table_name}.deleted_at is not null")
       }
     end
   end


### PR DESCRIPTION
Fixes possible ambiguous column 'deleted_at' issue if the following were attempted:
Alpha.joins(:beta).only_deleted
