### PR TITLE
Add support for dependent: :destroy! and :delete!

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ class AddDeletedAtToClient < ActiveRecord::Migration
   end
 end
 ```
-    
+
 ### Usage
 
 #### In your model:
@@ -98,6 +98,19 @@ find_with_deleted(id)         # => with_deleted.find(id)
 find_only_deleted(:all)       # => only_deleted
 find_only_deleted(:first)     # => only_deleted.first
 find_only_deleted(id)         # => only_deleted.find(id)
+```
+
+Paranoia also provides new dependent options for associations:
+
+```ruby
+
+# By default, associations with `dependent: :destroy` or `dependent: :delete`
+# will soft-delete associated records (with or without callbacks, respectively).
+# If you want to hard-delete paranoid dependencies, you can use:
+has_one :widget, dependent: :destroy! # fires callbacks, hard-deletes
+has_one :widget, dependent: :delete! # no callbacks, hard-deletes
+has_many :widgets, dependent: :destroy! # fires callbacks for all objects
+# has_many :widgets, dependent: :delete_all is unchanged, hard-deletes w/o callbacks
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ has_many :widgets, dependent: :destroy! # fires callbacks for all objects, hard-
 # has_many :widgets, dependent: :delete_all is unchanged, hard-deletes w/o callbacks
 ```
 
+Note that hard-deletion doesn't cascade -- if your User class `has_many
+widgets, dependent: destroy!` and Widget `has_many components, dependent:
+destroy`, the latter will be soft-deleted when the User is destroyed.  In this
+case, you should add a `:through` relationship to in the original object.
+
 ## License
 
 This gem is released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Paranoia also provides new dependent options for associations:
 # If you want to hard-delete paranoid dependencies, you can use:
 has_one :widget, dependent: :destroy! # fires callbacks, hard-deletes
 has_one :widget, dependent: :delete! # no callbacks, hard-deletes
-has_many :widgets, dependent: :destroy! # fires callbacks for all objects
+has_many :widgets, dependent: :destroy! # fires callbacks for all objects, hard-deletes
 # has_many :widgets, dependent: :delete_all is unchanged, hard-deletes w/o callbacks
 ```
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -41,21 +41,4 @@ module Paranoia
   end
 end
 
-class ActiveRecord::Base
-  def self.acts_as_paranoid
-    alias_method :destroy!, :destroy
-    alias_method :delete!,  :delete
-    include Paranoia
-    default_scope :conditions => { :deleted_at => nil }
-  end
-
-  def self.paranoid? ; false ; end
-  def paranoid? ; self.class.paranoid? ; end
-
-  # Override the persisted method to allow for the paranoia gem.
-  # If a paranoid record is selected, then we only want to check
-  # if it's a new record, not if it is "destroyed".
-  def persisted?
-    paranoid? ? !new_record? : super
-  end
-end
+require 'paranoia/active_record'

--- a/lib/paranoia/active_record.rb
+++ b/lib/paranoia/active_record.rb
@@ -1,0 +1,22 @@
+module ActiveRecord
+  class Base
+    def self.acts_as_paranoid
+      alias_method :destroy!, :destroy
+      alias_method :delete!,  :delete
+      include Paranoia
+      default_scope :conditions => { :deleted_at => nil }
+    end
+
+    def self.paranoid? ; false ; end
+    def paranoid? ; self.class.paranoid? ; end
+
+    # Override the persisted method to allow for the paranoia gem.
+    # If a paranoid record is selected, then we only want to check
+    # if it's a new record, not if it is "destroyed".
+    def persisted?
+      paranoid? ? !new_record? : super
+    end
+  end
+
+  require 'paranoia/active_record_associations'
+end

--- a/lib/paranoia/active_record_associations.rb
+++ b/lib/paranoia/active_record_associations.rb
@@ -1,0 +1,109 @@
+module ActiveRecord
+  # Update associations to allow hard-deleting dependencies.
+  module Associations
+    # properly set up class heirarchy
+    class Association; end
+    class SingularAssociation < Association; end
+    class CollectionAssociation < Association; end
+
+    # from rails/activerecord/lib/active_record/associations/has_one_association.rb
+    class HasOneAssociation < SingularAssociation #:nodoc:
+      def delete(method = options[:dependent])
+        if load_target
+          case method
+          when :delete
+            target.delete
+          when :destroy
+            target.destroy
+          when :delete!
+            target.delete!
+          when :destroy!
+            target.destroy!
+          when :nullify
+            target.update_column(reflection.foreign_key, nil)
+          end
+        end
+      end
+    end
+
+    # from rails/activerecord/lib/active_record/associations/has_many_association.rb
+    class HasManyAssociation < CollectionAssociation
+      # Deletes the records according to the <tt>:dependent</tt> option.
+      def delete_records(records, method)
+        if method == :destroy || method == :destroy!
+          records.each { |r| r.send(method) }
+          update_counter(-records.length) unless inverse_updates_counter_cache?
+        else
+          keys  = records.map { |r| r[reflection.association_primary_key] }
+          scope = scoped.where(reflection.association_primary_key => keys)
+
+          if method == :delete_all
+            update_counter(-scope.delete_all)
+          else
+            update_counter(-scope.update_all(reflection.foreign_key => nil))
+          end
+        end
+      end
+    end
+
+    # Allow our new options in
+    module Builder
+      # properly set up class heirarchy
+      class Association; end
+      class SingularAssociation < Association; end
+      class CollectionAssociation < Association; end
+
+      class HasOne < SingularAssociation
+        # Rails 4
+        def valid_dependent_options
+          [
+           :destroy, :delete, :nullify, :restrict, :restrict_with_error, :restrict_with_exception,
+           :destroy!, :delete!
+          ]
+        end
+
+        # Rails 3.2.x
+        def configure_dependency
+          if options[:dependent]
+            unless valid_dependent_options.include?(options[:dependent])
+              raise ArgumentError, "The :dependent option expects one of " \
+                "#{valid_dependent_options.join(", ")} (received #{options[:dependent].inspect})"
+            end
+
+            # map the ! methods to their non-! counterparts
+            method_name = options[:dependent].to_s.gsub(/\!/, "")
+            send("define_#{method_name}_dependency_method")
+            model.before_destroy dependency_method_name
+          end
+        end
+
+        def dependency_method_name
+          method_name = options[:dependent].to_s.gsub(/\!/, "")
+          "has_one_dependent_#{method_name}_for_#{name}"
+        end
+      end
+
+      class HasMany < CollectionAssociation
+        def valid_dependent_options
+          [
+            :destroy, :delete_all, :nullify, :restrict, :restrict_with_error, :restrict_with_exception,
+            :destroy!
+          ]
+        end
+
+        def configure_dependency
+          if options[:dependent]
+            unless valid_dependent_options.include?(options[:dependent])
+              raise ArgumentError, "The :dependent option expects one of " \
+                "#{valid_dependent_options.join(", ")} (received #{options[:dependent].inspect})"
+            end
+
+            method_name = options[:dependent].to_s.gsub(/\!/, "")
+            send("define_#{method_name}_dependency_method")
+            model.before_destroy dependency_method_name
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've been using Paranoia in one of our projects at @6Wunderkinder, and it's been extremely useful.  However, one gap we've found is that there are cases when you want to hard-destroy dependent resources -- for instance, when a user destroys her account, all related resources should be wiped from the database rather than left there orphaned.

This pull request adds support for `dependent: destroy!` (for HasOne and HasMany) and `dependent: delete!` (for HasOne -- delete_all for HasMany works out of the box).  These options function as expected, calling callbacks or not and then hard-deleting the record.  

This works for Rails 3.1 and 3.2 (tested with 3.1.8, 3.2.0, and 3.2.9).  I started doing work on 3.0.x, but it turns out that the current version of Paranoia doesn't work with 3.0.x anyway -- ditto 4.0, which I may take a crack at later.  (It's unfortunately involves copying some code from ActiveRecord, but it's relatively minimal (and should be less once paranoia is extended to cover Rails 4.0.)

Thanks for the great gem!
