### PR TITLE
Change that addresses #37

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -37,7 +37,7 @@ module Paranoia
 
   # Rails 3.1 adds update_column. Rails > 3.2.6 deprecates update_attribute, gone in Rails 4.
   def update_attribute_or_column(*args)
-    respond_to?(:update_column) ? update_column(*args) : update_attribute(*args)
+    respond_to?(:update_attribute) ? update_attribute(*args) : update_column(*args)
   end
 end
 


### PR DESCRIPTION
update_attribute does not seem to have this problem, where update_column does. So I'm proposing to use update_attribute where available.

I'm really not sure about older versions of Rails however so it may need more testing.
