### PR TITLE
fix alias methods

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -43,8 +43,8 @@ end
 
 class ActiveRecord::Base
   def self.acts_as_paranoid
-    alias_method :destroy!, :destroy
-    alias_method :delete!,  :delete
+    alias :destroy! :destroy
+    alias :delete!  :delete
     include Paranoia
     default_scope :conditions => { :deleted_at => nil }
   end


### PR DESCRIPTION
The test `test_real_destroy` failed when the test is run with ruby 2.0
The fix uses `alias` instead of `alias_method` to make sure `destroy` in active_record is used.
