### PR TITLE
Adding test with joining a paranoia model.

### DIFF
--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -73,7 +73,7 @@ class ParanoiaTest < Test::Unit::TestCase
     assert_equal 0, model.class.count
     assert_equal 1, model.class.unscoped.count
   end
-  
+
   def test_scoping_behavior_for_paranoid_models
     ParanoidModel.unscoped.delete_all
     parent1 = ParentModel.create
@@ -204,6 +204,19 @@ class ParanoiaTest < Test::Unit::TestCase
     model.delete!
 
     assert_equal false, ParanoidModel.unscoped.exists?(model.id)
+  end
+
+  def test_join_queries_work
+    parent = ParentModel.create
+    assert_equal 0, parent.related_models.count
+
+    child = parent.related_models.create
+    assert_equal 1, parent.related_models.count
+
+    child.destroy
+    assert_equal false, child.deleted_at.nil?
+    models = ParentModel.joins(:related_models).where(related_models: {id: child.id})
+    assert_equal [], models
   end
 
   private


### PR DESCRIPTION
This is something I've stumbled on and lost a few hours. If I remove a child object and then query for parent objects which relates to child models, I find records I should not.

Merging {deleted_at: nil} on the child query works.

While this might be a bug on Rails, or even might be intended behavior, I think the default scope should apply here. What do you think?
