### PR TITLE
Fix compability with rails 4.0

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -16,7 +16,7 @@ module Paranoia
   end
 
   def destroy
-    _run_destroy_callbacks { delete }
+    run_callbacks(:destroy) { delete }
   end
 
   def delete


### PR DESCRIPTION
ActiveSupport callbacks changed in Rails 4.0: now it does not create _run_*_callbacks methods.
