### PR TITLE
Fixes ActiveRecord 4.0 warning

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -45,7 +45,7 @@ class ActiveRecord::Base
     alias :destroy! :destroy
     alias :delete!  :delete
     include Paranoia
-    default_scope :conditions => { :deleted_at => nil }
+    default_scope { where(:deleted_at => nil) }
   end
 
   def self.paranoid? ; false ; end


### PR DESCRIPTION
It seems that AR 4.0 has changed how to define default scopes.
