### PR TITLE
use Model.all instead of Model.scoped

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -7,11 +7,11 @@ module Paranoia
     def paranoid? ; true ; end
 
     def only_deleted
-      scoped.tap { |x| x.default_scoped = false }.where("#{self.table_name}.deleted_at is not null")
+      all.tap { |x| x.default_scoped = false }.where("#{self.table_name}.deleted_at is not null")
     end
 
     def with_deleted
-      scoped.tap { |x| x.default_scoped = false }
+      all.tap { |x| x.default_scoped = false }
     end
   end
 


### PR DESCRIPTION
Since Rails 4, Model.all returns an ActiveRecord::Relation, rather than an array of records. 
This PR gets rid of the deprecation warnings BUT it will break some code.
