### PR TITLE
Mongoid Paranoia Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -9,11 +9,11 @@ module Paranoia
     end
 
     def only_deleted
-      scoped.tap { |x| x.default_scoped = false }.where("#{self.table_name}.deleted_at IS NOT NULL")
+      all.tap { |x| x.default_scoped = false }.where("#{self.table_name}.deleted_at IS NOT NULL")
     end
 
     def with_deleted
-      scoped.tap { |x| x.default_scoped = false }
+      all.tap { |x| x.default_scoped = false }
     end
   end
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -9,12 +9,12 @@ module Paranoia
     end
 
     def only_deleted
-      all.tap { |x| x.default_scoped = false }.where("#{self.table_name}.deleted_at IS NOT NULL")
+      scoped.tap { |x| x.default_scoped = false }.where("#{self.table_name}.deleted_at IS NOT NULL")
     end
     alias :deleted :only_deleted
 
     def with_deleted
-      all.tap { |x| x.default_scoped = false }
+      scoped.tap { |x| x.default_scoped = false }
     end
   end
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -11,6 +11,7 @@ module Paranoia
     def only_deleted
       all.tap { |x| x.default_scoped = false }.where("#{self.table_name}.deleted_at IS NOT NULL")
     end
+    alias :deleted :only_deleted
 
     def with_deleted
       all.tap { |x| x.default_scoped = false }
@@ -29,6 +30,7 @@ module Paranoia
   def restore!
     update_attribute_or_column :deleted_at, nil
   end
+  alias :restore :restore!
 
   def destroyed?
     !self.deleted_at.nil?

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -4,10 +4,12 @@ module Paranoia
   end
 
   module Query
-    def paranoid? ; true ; end
+    def paranoid?
+      true
+    end
 
     def only_deleted
-      scoped.tap { |x| x.default_scoped = false }.where("#{self.table_name}.deleted_at is not null")
+      scoped.tap { |x| x.default_scoped = false }.where("#{self.table_name}.deleted_at IS NOT NULL")
     end
 
     def with_deleted
@@ -31,6 +33,7 @@ module Paranoia
   def destroyed?
     !self.deleted_at.nil?
   end
+
   alias :deleted? :destroyed?
 
   private
@@ -44,13 +47,18 @@ end
 class ActiveRecord::Base
   def self.acts_as_paranoid
     alias :destroy! :destroy
-    alias :delete!  :delete
+    alias :delete! :delete
     include Paranoia
-    default_scope { where(:deleted_at => nil) }
+    default_scope { where(deleted_at: nil) }
   end
 
-  def self.paranoid? ; false ; end
-  def paranoid? ; self.class.paranoid? ; end
+  def self.paranoid?
+    false
+  end
+
+  def paranoid?
+    self.class.paranoid?
+  end
 
   # Override the persisted method to allow for the paranoia gem.
   # If a paranoid record is selected, then we only want to check

--- a/lib/paranoia/version.rb
+++ b/lib/paranoia/version.rb
@@ -1,3 +1,3 @@
 module Paranoia
-  VERSION = '1.2.0'
+  VERSION = '1.3.1'
 end

--- a/lib/paranoia/version.rb
+++ b/lib/paranoia/version.rb
@@ -1,3 +1,3 @@
 module Paranoia
-  VERSION = "1.2.0"
+  VERSION = '1.2.0'
 end

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -2,25 +2,26 @@
 require File.expand_path('../lib/paranoia/version', __FILE__)
 
 Gem::Specification.new do |s|
-  s.name        = 'paranoia'
-  s.version     = Paranoia::VERSION
-  s.platform    = Gem::Platform::RUBY
-  s.authors     = %w(radarlistener@gmail.com)
-  s.email       = []
-  s.homepage    = 'http://rubygems.org/gems/paranoia'
-  s.summary     = 'Paranoia is a re-implementation of acts_as_paranoid for Rails 3, using much, much, much less code.'
+  s.name = 'paranoia'
+  s.version = Paranoia::VERSION
+  s.platform = Gem::Platform::RUBY
+  s.authors = %w(radarlistener@gmail.com)
+  s.email = []
+  s.homepage = 'http://rubygems.org/gems/paranoia'
+  s.summary = 'Paranoia is a re-implementation of acts_as_paranoid for Rails 3, using much, much, much less code.'
   s.description = "Paranoia is a re-implementation of acts_as_paranoid for Rails 3, using much, much, much less code. You would use either plugin / gem if you wished that when you called destroy on an Active Record object that it didn't actually destroy it, but just \"hid\" the record. Paranoia does this by setting a deleted_at field to the current time when you destroy a record, and hides it by scoping all queries on your model to only include records which do not have a deleted_at field."
 
   s.required_rubygems_version = '>= 1.3.6'
-  s.rubyforge_project         = 'paranoia'
-  
+  s.rubyforge_project = 'paranoia'
+
   s.add_dependency 'activerecord', '>= 3.1.0'
 
   s.add_development_dependency 'bundler', '>= 1.0.0'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rake'
-  
-  s.files        = `git ls-files`.split("\n")
-  s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact
+  s.add_development_dependency 'debugger'
+
+  s.files = `git ls-files`.split("\n")
+  s.executables = `git ls-files`.split("\n").map { |f| f =~ /^bin\/(.*)/ ? $1 : nil }.compact
   s.require_path = 'lib'
 end

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler', '>= 1.0.0'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'debugger'
 
   s.files = `git ls-files`.split("\n")
   s.executables = `git ls-files`.split("\n").map { |f| f =~ /^bin\/(.*)/ ? $1 : nil }.compact

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project = 'paranoia'
 
-  s.add_dependency 'activerecord', '>= 3.1.0'
+  s.add_dependency 'activerecord', '~> 3.2'
 
   s.add_development_dependency 'bundler', '>= 1.0.0'
   s.add_development_dependency 'sqlite3'

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler', '>= 1.0.0'
   s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'rake', '0.8.7'
+  s.add_development_dependency 'rake'
   
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -1,24 +1,24 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path("../lib/paranoia/version", __FILE__)
+require File.expand_path('../lib/paranoia/version', __FILE__)
 
 Gem::Specification.new do |s|
-  s.name        = "paranoia"
+  s.name        = 'paranoia'
   s.version     = Paranoia::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["radarlistener@gmail.com"]
+  s.authors     = %w(radarlistener@gmail.com)
   s.email       = []
-  s.homepage    = "http://rubygems.org/gems/paranoia"
-  s.summary     = "Paranoia is a re-implementation of acts_as_paranoid for Rails 3, using much, much, much less code."
+  s.homepage    = 'http://rubygems.org/gems/paranoia'
+  s.summary     = 'Paranoia is a re-implementation of acts_as_paranoid for Rails 3, using much, much, much less code.'
   s.description = "Paranoia is a re-implementation of acts_as_paranoid for Rails 3, using much, much, much less code. You would use either plugin / gem if you wished that when you called destroy on an Active Record object that it didn't actually destroy it, but just \"hid\" the record. Paranoia does this by setting a deleted_at field to the current time when you destroy a record, and hides it by scoping all queries on your model to only include records which do not have a deleted_at field."
 
-  s.required_rubygems_version = ">= 1.3.6"
-  s.rubyforge_project         = "paranoia"
+  s.required_rubygems_version = '>= 1.3.6'
+  s.rubyforge_project         = 'paranoia'
   
-  s.add_dependency "activerecord", ">= 3.1.0"
+  s.add_dependency 'activerecord', '>= 3.1.0'
 
-  s.add_development_dependency "bundler", ">= 1.0.0"
-  s.add_development_dependency "sqlite3"
-  s.add_development_dependency "rake", "0.8.7"
+  s.add_development_dependency 'bundler', '>= 1.0.0'
+  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'rake', '0.8.7'
   
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -83,6 +83,7 @@ class ParanoiaTest < Test::Unit::TestCase
     p2.destroy
     assert_equal 0, parent1.paranoid_models.count
     assert_equal 1, parent1.paranoid_models.only_deleted.count
+    assert_equal 1, parent1.paranoid_models.deleted.count
     p3 = ParanoidModel.create(:parent_model => parent1)
     assert_equal 2, parent1.paranoid_models.with_deleted.count
     assert_equal [p1, p3], parent1.paranoid_models.with_deleted
@@ -117,6 +118,7 @@ class ParanoiaTest < Test::Unit::TestCase
 
     assert_equal model, ParanoidModel.only_deleted.last
     assert_equal false, ParanoidModel.only_deleted.include?(model2)
+    assert_equal false, ParanoidModel.deleted.include?(model2)
   end
 
   def test_default_scope_for_has_many_relationships

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -1,6 +1,6 @@
 require 'test/unit'
 require 'active_record'
-require File.expand_path(File.dirname(__FILE__) + "/../lib/paranoia")
+require File.expand_path(File.dirname(__FILE__) + '/../lib/paranoia')
 
 DB_FILE = 'tmp/test_db'
 
@@ -71,7 +71,7 @@ class ParanoiaTest < Test::Unit::TestCase
     assert_equal 0, model.class.count
     assert_equal 1, model.class.unscoped.count
   end
-  
+
   def test_scoping_behavior_for_paranoid_models
     ParanoidModel.unscoped.delete_all
     parent1 = ParentModel.create
@@ -84,7 +84,7 @@ class ParanoiaTest < Test::Unit::TestCase
     assert_equal 1, parent1.paranoid_models.only_deleted.count
     p3 = ParanoidModel.create(:parent_model => parent1)
     assert_equal 2, parent1.paranoid_models.with_deleted.count
-    assert_equal [p1,p3], parent1.paranoid_models.with_deleted
+    assert_equal [p1, p3], parent1.paranoid_models.with_deleted
   end
 
   def test_destroy_behavior_for_featureful_paranoid_models
@@ -102,8 +102,8 @@ class ParanoiaTest < Test::Unit::TestCase
 
   # Regression test for #24
   def test_chaining_for_paranoid_models
-    scope = FeaturefulModel.where(:name => "foo").only_deleted
-    assert_equal "foo", scope.where_values_hash[:name]
+    scope = FeaturefulModel.where(:name => 'foo').only_deleted
+    assert_equal 'foo', scope.where_values_hash[:name]
     assert_equal 2, scope.where_values.count
   end
 
@@ -206,7 +206,7 @@ class ParanoiaTest < Test::Unit::TestCase
 
   private
   def get_featureful_model
-    FeaturefulModel.new(:name => "not empty")
+    FeaturefulModel.new(:name => 'not empty')
   end
 end
 
@@ -231,7 +231,7 @@ end
 
 class CallbackModel < ActiveRecord::Base
   acts_as_paranoid
-  before_destroy {|model| model.instance_variable_set :@callback_called, true }
+  before_destroy { |model| model.instance_variable_set :@callback_called, true }
 end
 
 class ParentModel < ActiveRecord::Base

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -1,6 +1,5 @@
 require 'test/unit'
 require 'active_record'
-require 'debugger'
 require File.expand_path(File.dirname(__FILE__) + '/../lib/paranoia')
 
 DB_FILE = 'tmp/test_db'

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -1,5 +1,6 @@
 require 'test/unit'
 require 'active_record'
+require 'debugger'
 require File.expand_path(File.dirname(__FILE__) + '/../lib/paranoia')
 
 DB_FILE = 'tmp/test_db'
@@ -103,7 +104,7 @@ class ParanoiaTest < Test::Unit::TestCase
   # Regression test for #24
   def test_chaining_for_paranoid_models
     scope = FeaturefulModel.where(:name => 'foo').only_deleted
-    assert_equal 'foo', scope.where_values_hash[:name]
+    assert_equal 'foo', scope.where_values_hash['name']
     assert_equal 2, scope.where_values.count
   end
 
@@ -193,15 +194,14 @@ class ParanoiaTest < Test::Unit::TestCase
     model.save
     model.destroy!
 
-    assert_equal false, ParanoidModel.unscoped.exists?(model.id)
+    assert_equal 0, ParanoidModel.unscoped.where(id: model.id).count
   end
 
   def test_real_delete
     model = ParanoidModel.new
     model.save
     model.delete!
-
-    assert_equal false, ParanoidModel.unscoped.exists?(model.id)
+    assert_equal 0, ParanoidModel.unscoped.where(id: model.id).count
   end
 
   private


### PR DESCRIPTION
I'm adding some aliases to scopes so that the methods sync with Mongoid Paranoia methods. We're using polygot databases and I think it's nicer to have consistent methods across components tasked with doing the same thing.

Maybe one day I'll combine the two gems to work with ActiveRecord & Mongoid.

Also contains formatting changes.  If you use different formatting settings with your IDE I can adjust.

https://github.com/simi/mongoid-paranoia
