### PR TITLE
Fix issue with default scope clashing with deletion.

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -50,7 +50,9 @@ module Paranoia
 
   # Rails 3.1 adds update_column. Rails > 3.2.6 deprecates update_attribute, gone in Rails 4.
   def update_attribute_or_column(*args)
-    respond_to?(:update_column) ? update_column(*args) : update_attribute(*args)
+    self.class.unscoped do
+      respond_to?(:update_column) ? update_column(*args) : update_attribute(*args)
+    end
   end
 end
 


### PR DESCRIPTION
Fixes #37

In certain edge case scenarios default_scopes can interfere with the SQL Paranoia generates to issue a record hide.  Both `update_column` and `update_attribute` use default scopes. Take the following edge case scenario:

``` ruby
class User < ActiveRecord::Base
  default_scope :include => :login, :order => "logins.first_name" 
  belongs_to :login
  acts_as_paranoid
end
```

In this case Paranoia throws the following SQL error when trying to hide/destroy a User record: `ActiveRecord::StatementInvalid: PG::Error: ERROR:  missing FROM-clause entry for table "logins"`

My particular case is a very edge case scenario, but I can see the default scoping being a broader problem.

By adding unscoped to the deletion query default scope issues are avoided. In this case since Paranoia is simply saving an attribute on an already found and instantiated object, adding unscoped shouldn't impact the functionality of Paranoia at all. In fact, `unscoped` is only a class method.
