### PR TITLE
destroy! when destroying deleted? records

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Paranoia is a re-implementation of [acts\_as\_paranoid](http://github.com/techno
 
 You would use either plugin / gem if you wished that when you called `destroy` on an Active Record object that it didn't actually destroy it, but just "hid" the record. Paranoia does this by setting a `deleted_at` field to the current time when you `destroy` a record, and hides it by scoping all queries on your model to only include records which do not have a `deleted_at` field.
 
+If you wish to actually destroy an object you may call destroy! on it or simply call destroy twice on the same object.
+
 ## Installation & Usage
 
 For Rails 3, please use version 1 of Paranoia:

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -31,8 +31,8 @@ module Paranoia
   end
 
   def delete
-    return if new_record? or destroyed?
-    update_attribute_or_column :deleted_at, Time.now
+    return if new_record?
+    destroyed? ? destroy! : update_attribute_or_column(:deleted_at, Time.now)
   end
 
   def restore!

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -190,6 +190,15 @@ class ParanoiaTest < Test::Unit::TestCase
     assert_equal false, model.destroyed?
   end
 
+  def test_destroy_twice
+    model = ParanoidModel.new
+    model.save
+    model.destroy
+    model.destroy
+
+    assert_equal 0, ParanoidModel.unscoped.where(id: model.id).count
+  end
+
   def test_real_destroy
     model = ParanoidModel.new
     model.save


### PR DESCRIPTION
It would be really nice if destroying a destroyed object deleted it from a db.

It provides for destroy working as expected for has_many relationships (first destroy marks them all, second call will remove them all)

It also allows for destroy_all to work for destroying records permanently with 'with_deleted.destroy_all'

This is consistent with other act_as_paranoid gems
