### PR TITLE
Use quoted table name in default scope (call me paranoid)

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -66,7 +66,7 @@ class ActiveRecord::Base
     alias :destroy! :destroy
     alias :delete!  :delete
     include Paranoia
-    default_scope { where(:deleted_at => nil) }
+    default_scope { where(self.quoted_table_name + '.deleted_at IS NULL') }
   end
 
   def self.paranoid? ; false ; end


### PR DESCRIPTION
For some reason, in our spree app, a `has_many :through` association was confusing which table to apply the paranoia's `default_scope` to. The only reliable solution I could find was to use some raw SQL in the default_scope's where clause.

Specifically, the `:has_many` relation defined here: https://github.com/spree/spree/blob/master/core/app/models/spree/product.rb#L66 includes the Variant model's default scope that is set by paranoia. However it was mistakenly outputting SQL on the primary association model (Image) whose table name is `spree_assets`. Here's an example of the error we were getting:

``` ruby
p = Spree::Product.last
[2] pry(main)> p.variant_images
  Spree::Image Load (0.6ms)  SELECT `spree_assets`.* FROM `spree_assets` INNER JOIN `spree_variants` ON `spree_assets`.`viewable_id` = `spree_variants`.`id` AND `spree_assets`.`viewable_type` = 'Spree::Variant' WHERE `spree_assets`.`deleted_at` IS NULL AND `spree_assets`.`type` IN ('Spree::Image') AND `spree_variants`.`product_id` = 101 ORDER BY `spree_assets`.position ASC, `spree_variants`.position ASC
Mysql2::Error: Unknown column 'spree_assets.deleted_at' in 'where clause': SELECT `spree_assets`.* FROM `spree_assets` INNER JOIN `spree_variants` ON `spree_assets`.`viewable_id` = `spree_variants`.`id` AND `spree_assets`.`viewable_type` = 'Spree::Variant' WHERE `spree_assets`.`deleted_at` IS NULL AND `spree_assets`.`type` IN ('Spree::Image') AND `spree_variants`.`product_id` = 101  ORDER BY `spree_assets`.position ASC, `spree_variants`.position ASC
=> #<ActiveRecord::Associations::CollectionProxy::ActiveRecord_Associations_CollectionProxy_Spree_Image:0x3fd7b3b81ee0>
```

All the tests seem to still be passing. What do you think?
