### PR TITLE
use force_* methods instead of bang methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in paranoia.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ class Client < ActiveRecord::Base
 end
 ```
 
+If you want to use a column other than deleted_at, you can pass it as an option:
+
+```ruby
+class Client < ActiveRecord::Base
+  acts_as_paranoid column: :destroyed_at
+
+  ...
+end
+```
+
 You can replace the older acts_as_paranoid methods as follows:
 
 | Old Syntax                 | New Syntax                     |

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -67,7 +67,7 @@ class ActiveRecord::Base
     alias :destroy! :destroy
     alias :delete!  :delete
     include Paranoia
-    default_scope { where(:deleted_at => nil) }
+    default_scope { where(self.quoted_table_name + '.deleted_at IS NULL') }
   end
 
   def self.paranoid? ; false ; end

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -49,7 +49,7 @@ module Paranoia
 
   def delete
     return if new_record?
-    destroyed? ? destroy! : update_column(:deleted_at, Time.now)
+    destroyed? ? force_destroy : update_column(:deleted_at, Time.now)
   end
 
   def restore!
@@ -64,8 +64,8 @@ end
 
 class ActiveRecord::Base
   def self.acts_as_paranoid
-    alias :destroy! :destroy
-    alias :delete!  :delete
+    alias :force_destroy :destroy
+    alias :force_delete  :delete
     include Paranoia
     default_scope { where(self.quoted_table_name + '.deleted_at IS NULL') }
   end

--- a/lib/paranoia/version.rb
+++ b/lib/paranoia/version.rb
@@ -1,3 +1,3 @@
 module Paranoia
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -60,6 +60,14 @@ class ParanoiaTest < Test::Unit::TestCase
     assert_equal 0, model.class.unscoped.count
   end
 
+  # Anti-regression test for #81, which would've introduced a bug to break this test.
+  def test_destroy_behavior_for_plain_models_callbacks
+    model = CallbackModel.new
+    model.destroy
+    assert_equal nil, model.instance_variable_get(:@update_callback_called)
+    assert_equal nil, model.instance_variable_get(:@save_callback_called)
+  end
+
   def test_destroy_behavior_for_paranoid_models
     model = ParanoidModel.new
     assert_equal 0, model.class.count
@@ -182,14 +190,14 @@ class ParanoiaTest < Test::Unit::TestCase
     model = CallbackModel.new
     model.save
     model.delete
-    assert_equal nil, model.instance_variable_get(:@callback_called)
+    assert_equal nil, model.instance_variable_get(:@destroy_callback_called)
   end
 
   def test_destroy_behavior_for_callbacks
     model = CallbackModel.new
     model.save
     model.destroy
-    assert model.instance_variable_get(:@callback_called)
+    assert model.instance_variable_get(:@destroy_callback_called)
   end
 
   def test_restore
@@ -301,8 +309,10 @@ end
 
 class CallbackModel < ActiveRecord::Base
   acts_as_paranoid
-  before_destroy {|model| model.instance_variable_set :@callback_called, true }
+  before_destroy {|model| model.instance_variable_set :@destroy_callback_called, true }
   before_restore {|model| model.instance_variable_set :@restore_callback_called, true }
+  before_update  {|model| model.instance_variable_set :@update_callback_called, true }
+  before_save    {|model| model.instance_variable_set :@save_callback_called, true}
 end
 
 class ParentModel < ActiveRecord::Base

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -17,6 +17,7 @@ ActiveRecord::Base.connection.execute 'CREATE TABLE related_models (id INTEGER N
 ActiveRecord::Base.connection.execute 'CREATE TABLE employers (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE employees (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE jobs (id INTEGER NOT NULL PRIMARY KEY, employer_id INTEGER NOT NULL, employee_id INTEGER NOT NULL, deleted_at DATETIME)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE custom_column_models (id INTEGER NOT NULL PRIMARY KEY, destroyed_at DATETIME)'
 
 class ParanoiaTest < Test::Unit::TestCase
   def test_plain_model_class_is_not_paranoid
@@ -86,6 +87,23 @@ class ParanoiaTest < Test::Unit::TestCase
     p3 = ParanoidModel.create(:parent_model => parent1)
     assert_equal 2, parent1.paranoid_models.with_deleted.count
     assert_equal [p1,p3], parent1.paranoid_models.with_deleted
+  end
+
+  def test_destroy_behavior_for_custom_column_models
+    model = CustomColumnModel.new
+    assert_equal 0, model.class.count
+    model.save!
+    assert_nil model.destroyed_at
+    assert_equal 1, model.class.count
+    model.destroy
+
+    assert_equal false, model.destroyed_at.nil?
+    assert model.destroyed?
+
+    assert_equal 0, model.class.count
+    assert_equal 1, model.class.unscoped.count
+    assert_equal 1, model.class.only_deleted.count
+    assert_equal 1, model.class.deleted.count
   end
 
   def test_destroy_behavior_for_featureful_paranoid_models
@@ -313,4 +331,8 @@ class Job < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :employer
   belongs_to :employee
+end
+
+class CustomColumnModel < ActiveRecord::Base
+  acts_as_paranoid column: :destroyed_at
 end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -213,18 +213,18 @@ class ParanoiaTest < Test::Unit::TestCase
     assert model.instance_variable_get(:@restore_callback_called)
   end
 
-  def test_real_destroy
+  def test_force_destroy
     model = ParanoidModel.new
     model.save
-    model.destroy!
+    model.force_destroy
 
     refute ParanoidModel.unscoped.exists?(model.id)
   end
 
-  def test_real_delete
+  def test_force_delete
     model = ParanoidModel.new
     model.save
-    model.delete!
+    model.force_delete
 
     refute ParanoidModel.unscoped.exists?(model.id)
   end


### PR DESCRIPTION
It should solve #67.

However, **this is not backward compatible** as the bang methods (`destroy!` and `delete!`) have been completely removed.

Alternatively, we could keep the bang methods for now and add a deprecation warning (?)
