### PR TITLE
Add configuration option for column name in Rails 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ class Client < ActiveRecord::Base
 end
 ```
 
+If you want to use a column other than deleted_at, you can pass it as an option:
+
+```ruby
+class Client < ActiveRecord::Base
+  acts_as_paranoid column: :destroyed_at
+
+  ...
+end
+```
+
 You can replace the older acts_as_paranoid methods as follows:
 
 | Old Syntax                 | New Syntax                     |

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -12,7 +12,7 @@ module Paranoia
     end
 
     def only_deleted
-      with_deleted.where.not(deleted_at: nil)
+      with_deleted.where.not(paranoia_column => nil)
     end
     alias :deleted :only_deleted
 
@@ -49,25 +49,28 @@ module Paranoia
 
   def delete
     return if new_record?
-    destroyed? ? destroy! : update_column(:deleted_at, Time.now)
+    destroyed? ? destroy! : update_column(paranoia_column, Time.now)
   end
 
   def restore!
-    run_callbacks(:restore) { update_column :deleted_at, nil }
+    run_callbacks(:restore) { update_column paranoia_column, nil }
   end
 
   def destroyed?
-    !!deleted_at
+    !!send(paranoia_column)
   end
   alias :deleted? :destroyed?
 end
 
 class ActiveRecord::Base
-  def self.acts_as_paranoid
+  def self.acts_as_paranoid(options={})
     alias :destroy! :destroy
     alias :delete!  :delete
     include Paranoia
-    default_scope { where(self.quoted_table_name + '.deleted_at IS NULL') }
+    class_attribute :paranoia_column
+
+    self.paranoia_column = options[:column] || :deleted_at
+    default_scope { where(self.quoted_table_name + ".#{paranoia_column} IS NULL") }
   end
 
   def self.paranoid? ; false ; end
@@ -78,5 +81,11 @@ class ActiveRecord::Base
   # if it's a new record, not if it is "destroyed".
   def persisted?
     paranoid? ? !new_record? : super
+  end
+
+  private
+
+  def paranoia_column
+    self.class.paranoia_column
   end
 end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -17,6 +17,7 @@ ActiveRecord::Base.connection.execute 'CREATE TABLE related_models (id INTEGER N
 ActiveRecord::Base.connection.execute 'CREATE TABLE employers (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE employees (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE jobs (id INTEGER NOT NULL PRIMARY KEY, employer_id INTEGER NOT NULL, employee_id INTEGER NOT NULL, deleted_at DATETIME)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE custom_column_models (id INTEGER NOT NULL PRIMARY KEY, destroyed_at DATETIME)'
 
 class ParanoiaTest < Test::Unit::TestCase
   def test_plain_model_class_is_not_paranoid
@@ -86,6 +87,23 @@ class ParanoiaTest < Test::Unit::TestCase
     p3 = ParanoidModel.create(:parent_model => parent1)
     assert_equal 2, parent1.paranoid_models.with_deleted.count
     assert_equal [p1,p3], parent1.paranoid_models.with_deleted
+  end
+
+  def test_destroy_behavior_for_custom_column_models
+    model = CustomColumnModel.new
+    assert_equal 0, model.class.count
+    model.save!
+    assert_nil model.destroyed_at
+    assert_equal 1, model.class.count
+    model.destroy
+
+    assert_equal false, model.destroyed_at.nil?
+    assert model.destroyed?
+
+    assert_equal 0, model.class.count
+    assert_equal 1, model.class.unscoped.count
+    assert_equal 1, model.class.only_deleted.count
+    assert_equal 1, model.class.deleted.count
   end
 
   def test_destroy_behavior_for_featureful_paranoid_models
@@ -313,4 +331,8 @@ class Job < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :employer
   belongs_to :employee
+end
+
+class CustomColumnModel < ActiveRecord::Base
+  acts_as_paranoid column: :destroyed_at
 end


### PR DESCRIPTION
Pulling over a feature from acts_as_paranoid gem 

https://github.com/goncalossilva/acts_as_paranoid
