### PR TITLE
Make default_scope optional

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -14,6 +14,11 @@ module Paranoia
       scoped.tap { |x| x.default_scoped = false }
     end
 
+    def without_deleted
+      where(paranoia_column => nil)
+    end
+    alias :undeleted :without_deleted
+
     def only_deleted
       with_deleted.where("#{self.table_name}.#{paranoia_column} IS NOT NULL")
     end
@@ -84,7 +89,8 @@ class ActiveRecord::Base
     class_attribute :paranoia_column
 
     self.paranoia_column = options[:column] || :deleted_at
-    default_scope { where(self.quoted_table_name + ".#{paranoia_column} IS NULL") }
+
+    default_scope { without_deleted } unless options[:default_scope] == false
   end
 
   def self.paranoid?

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -15,12 +15,12 @@ module Paranoia
     end
 
     def without_deleted
-      where(paranoia_column => nil)
+      where("#{self.quoted_table_name}.#{paranoia_column} IS NULL")
     end
     alias :undeleted :without_deleted
 
     def only_deleted
-      with_deleted.where("#{self.table_name}.#{paranoia_column} IS NOT NULL")
+      with_deleted.where("#{self.quoted_table_name}.#{paranoia_column} IS NOT NULL")
     end
     alias :deleted :only_deleted
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -18,6 +18,7 @@ ActiveRecord::Base.connection.execute 'CREATE TABLE employers (id INTEGER NOT NU
 ActiveRecord::Base.connection.execute 'CREATE TABLE employees (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE jobs (id INTEGER NOT NULL PRIMARY KEY, employer_id INTEGER NOT NULL, employee_id INTEGER NOT NULL, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE custom_column_models (id INTEGER NOT NULL PRIMARY KEY, destroyed_at DATETIME)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE unscoped_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 
 class ParanoiaTest < Test::Unit::TestCase
   def test_plain_model_class_is_not_paranoid
@@ -274,6 +275,11 @@ class ParanoiaTest < Test::Unit::TestCase
     refute c.destroyed?
   end
 
+  def test_unscoped_model_default_scope
+    UnscopedModel.create(deleted_at: Time.now)
+    assert_equal 1, UnscopedModel.count
+  end
+
   private
   def get_featureful_model
     FeaturefulModel.new(:name => 'not empty')
@@ -335,4 +341,8 @@ end
 
 class CustomColumnModel < ActiveRecord::Base
   acts_as_paranoid column: :destroyed_at
+end
+
+class UnscopedModel < ActiveRecord::Base
+  acts_as_paranoid default_scope: false
 end


### PR DESCRIPTION
I added the opportunity to make the default_scope optional. This is inspired by the commit of the fork of joshuap in the rails4 branch. (https://github.com/joshuap/paranoia/commit/ff15d315e0ec425b4e4183742485abe53cd22ef1).

I would be glad if this is going into the master branch of radar/paranoia. I hope this helps the community.
