### PR TITLE
callback bugs for master

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -52,11 +52,11 @@ module Paranoia
 
   def delete
     return if new_record?
-    destroyed? ? destroy! : update_attributes(paranoia_column => Time.now)
+    destroyed? ? destroy! : update_attrs_without_valid(paranoia_column => Time.now)
   end
 
   def restore!
-    run_callbacks(:restore) { update_attributes(paranoia_column => nil) }
+    run_callbacks(:restore) { update_attrs_without_valid(paranoia_column => nil) }
   end
   alias :restore :restore!
 
@@ -65,6 +65,15 @@ module Paranoia
   end
 
   alias :deleted? :destroyed?
+
+  private
+
+  # update attributes without validation
+  # @param attributes [Hash] attributes
+  def update_attrs_without_valid(attributes)
+    assign_attributes(attributes)
+    save(:validate => false)
+  end
 
 end
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -52,11 +52,11 @@ module Paranoia
 
   def delete
     return if new_record?
-    destroyed? ? destroy! : update_attribute_or_column(paranoia_column, Time.now)
+    destroyed? ? destroy! : update_attributes(paranoia_column => Time.now)
   end
 
   def restore!
-    run_callbacks(:restore) { update_column paranoia_column, nil }
+    run_callbacks(:restore) { update_attributes(paranoia_column => nil) }
   end
   alias :restore :restore!
 
@@ -66,14 +66,6 @@ module Paranoia
 
   alias :deleted? :destroyed?
 
-  private
-
-  # Rails 3.1 adds update_column. Rails > 3.2.6 deprecates update_attribute, gone in Rails 4.
-  def update_attribute_or_column(*args)
-    self.class.unscoped do
-      respond_to?(:update_column) ? update_column(*args) : update_attribute(*args)
-    end
-  end
 end
 
 class ActiveRecord::Base


### PR DESCRIPTION
Hello,

In rails, after_commit must be called, when destroy.

but, Paranoid doesn't call it, because it uses update_column.

I have solved this problem using update_attributes.

update_attributes (alias to update)
 deprecated : false
 callbacks  : true

update_attributes 
 deprecated : true
 callbacks  : true

update_column
 deprecated : false
 callback   : false
