### PR TITLE
Failing test for joining a table multiple times

### DIFF
--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "sqlite3"
+  s.add_development_dependency "pg"
   s.add_development_dependency "rake", "0.8.7"
 
   s.files        = `git ls-files`.split("\n")


### PR DESCRIPTION
With activerecord 4.0.1 just using the `quoted_table_name` doesn't work in all cases as tables are now aliased when joined multiple times. (jobs_employees below)

``` sql
SELECT COUNT(*) FROM "employees"
INNER JOIN "jobs" "jobs_employees" ON 
  "jobs_employees"."employee_id" = "employees"."id" AND ("jobs".deleted_at IS NULL)
INNER JOIN "jobs" ON
  "employees"."id" = "jobs"."employee_id"
WHERE
  ("employees".deleted_at IS NULL) 
  AND ("jobs".deleted_at IS NULL) AND "jobs"."employer_id" = $1
```

sqlite3 ignores the wrong reference, but postgresql doesn't

```
ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:
  invalid reference to FROM-clause entry for table "jobs"
LINE 1: ..._employees"."employee_id" = "employees"."id" AND ("jobs".del...
                                                             ^
HINT:  Perhaps you meant to reference the table alias "jobs_employees".
```

I had to replace your plain sql model creation with ActiveRecord::Schema as PG is a bit different. Would you like to keep that?
