### PR TITLE
Replaced deprecated gemcutter source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in paranoia.gemspec
 gemspec


### PR DESCRIPTION
Changed source to remove deprecation warning while using bundler

```
The source :gemcutter is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
