### PR TITLE
Separate filter to a method

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -119,7 +119,7 @@ class ActiveRecord::Base
     class_attribute :paranoia_column
 
     self.paranoia_column = options[:column] || :deleted_at
-    default_scope { without_deleted } unless options[:default_scope] == false
+    default_scope { without_deleted }
 
     before_restore {
       self.class.notify_observers(:before_restore, self) if self.class.respond_to?(:notify_observers)

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -14,6 +14,11 @@ module Paranoia
       scoped.tap { |x| x.default_scoped = false }
     end
 
+    def without_deleted
+      where(paranoia_column => nil)
+    end
+    alias :undeleted :without_deleted
+
     def only_deleted
       with_deleted.where("#{self.table_name}.#{paranoia_column} IS NOT NULL")
     end
@@ -114,7 +119,7 @@ class ActiveRecord::Base
     class_attribute :paranoia_column
 
     self.paranoia_column = options[:column] || :deleted_at
-    default_scope { where(self.quoted_table_name + ".#{paranoia_column} IS NULL") }
+    default_scope { without_deleted } unless options[:default_scope] == false
 
     before_restore {
       self.class.notify_observers(:before_restore, self) if self.class.respond_to?(:notify_observers)
@@ -122,6 +127,7 @@ class ActiveRecord::Base
     after_restore {
       self.class.notify_observers(:after_restore, self) if self.class.respond_to?(:notify_observers)
     }
+
   end
 
   def self.paranoid?


### PR DESCRIPTION
We have a use case where we add filterings on the default scope. We are using that default scope on the public pages but on the admin pages we want to use the unscoped view of the model without the deleted items. Right now we are not able to do that without duplicating the filter in our controller. 

Example after pull request applied:

``` ruby
class Example < ActiveRecord::Base
  default_scope { where(available: true, visible: true).order(:plan_order) }
end

class ExampleController < ApplicationController
  def index
    Example.unscoped.without_deleted
  end
end
```
