### PR TITLE
Notify observers of paranoid restores

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -96,10 +96,10 @@ class ActiveRecord::Base
     default_scope { where(self.quoted_table_name + ".#{paranoia_column} IS NULL") }
 
     before_restore {
-      self.class.notify_observers(:before_restore) if self.class.respond_to?(:notify_observers)
+      self.class.notify_observers(:before_restore, self) if self.class.respond_to?(:notify_observers)
     }
     after_restore {
-      self.class.notify_observers(:after_restore) if self.class.respond_to?(:notify_observers)
+      self.class.notify_observers(:after_restore, self) if self.class.respond_to?(:notify_observers)
     }
   end
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -94,6 +94,9 @@ class ActiveRecord::Base
 
     self.paranoia_column = options[:column] || :deleted_at
     default_scope { where(self.quoted_table_name + ".#{paranoia_column} IS NULL") }
+
+    before_restore { notify_observers(:before_restore) if respond_to?(:notify_observers) }
+    after_restore { notify_observers(:after_restore) if respond_to?(:notify_observers) }
   end
 
   def self.paranoid?

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -95,8 +95,12 @@ class ActiveRecord::Base
     self.paranoia_column = options[:column] || :deleted_at
     default_scope { where(self.quoted_table_name + ".#{paranoia_column} IS NULL") }
 
-    before_restore { notify_observers(:before_restore) if respond_to?(:notify_observers) }
-    after_restore { notify_observers(:after_restore) if respond_to?(:notify_observers) }
+    before_restore {
+      self.class.notify_observers(:before_restore) if self.class.respond_to?(:notify_observers)
+    }
+    after_restore {
+      self.class.notify_observers(:after_restore) if self.class.respond_to?(:notify_observers)
+    }
   end
 
   def self.paranoid?

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -400,11 +400,11 @@ class ParanoidModelWithObservers < ParanoidModel
     @observers_notified ||= []
   end
 
-  def notify_observer(*args)
+  def self.notify_observer(*args)
     observers_notified << args
   end
 end
 
 class ParanoidModelWithoutObservers < ParanoidModel
-  remove_method :notify_observers if method_defined?(:notify_observers)
+  self.class.send(remove_method :notify_observers) if method_defined?(:notify_observers)
 end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -310,8 +310,8 @@ class ParanoiaTest < Test::Unit::TestCase
     a.destroy
     a.restore!
 
-    assert a.observers_notified.select {|args| args.first == :before_restore}
-    assert a.observers_notified.select {|args| args.first == :after_restore}
+    assert a.observers_notified.select {|args| args == [:before_restore, a]}
+    assert a.observers_notified.select {|args| args == [:after_restore, a]}
   end
 
   def test_observers_not_notified_if_not_supported


### PR DESCRIPTION
This pull request adds before and after restore hooks to notify ActiveRecord Observers if observers are available (e.g. if `notify_observers` is a method). It's compatible with both the built-in Rails 3 observers (which defines notify_observers through [inheritance](https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/observer.rb#L91) from [ActiveModel::Observers](https://github.com/rails/rails/blob/4cef581fcf83f161edcd681bbda1461d5f7d5f33/activemodel/lib/active_model/observing.rb#L72)) and Rails 4's [rails-observers](https://github.com/rails/rails-observers/blob/86bfe485dc393f821796f8310cf8bfc1fad6ab3d/lib/rails/observers/active_model/observing.rb#L132). For a description of notifying observers about custom actions, see http://blog.crowdint.com/2013/04/23/fun-with-activerecord-observer.html.

Paranoia and observers -- the jokes write themselves!
