### PR TITLE
JRuby and Rubinius support in specs, Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - jruby-19mode
+  - rbx

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,13 @@
 source 'https://rubygems.org'
 
+gem 'sqlite3', :platforms => [:ruby]
+gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
+
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'rubysl-test-unit'
+  gem 'rubinius-developer_tools'
+end
+
 # Specify your gem's dependencies in paranoia.gemspec
 gemspec

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord', '~> 3.2'
 
   s.add_development_dependency 'bundler', '>= 1.0.0'
-  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rake'
 
   s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
1. Updated Gemfile and gemspec to allow JRuby and Rubinius.
2. Added JRuby and Rubinius to .travis.yml

I'd also love to see this pulled over the rails4 branch (as that branch doesn't have any Travis integration at all).  Let me know if it would be helpful for me to submit a separate PR for that branch.
