### PR TITLE
Apply default scope depending on `apply_default_scope` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ class Client < ActiveRecord::Base
 end
 ```
 
+If you don't want your model to be scoped by default, you can pass a correspondent option:
+
+```ruby
+class Client < ActiveRecord::Base
+  acts_as_paranoid apply_default_scope: false
+
+  ...
+end
+
+...
+client.destroy
+Client.find(client.id) # no error
+```
+
 You can replace the older acts_as_paranoid methods as follows:
 
 | Old Syntax                 | New Syntax                     |

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -93,7 +93,11 @@ class ActiveRecord::Base
     class_attribute :paranoia_column
 
     self.paranoia_column = options[:column] || :deleted_at
-    default_scope { where(self.quoted_table_name + ".#{paranoia_column} IS NULL") }
+
+    apply_default_scope = options.key?(:apply_default_scope) ? options[:apply_default_scope] : true
+    if apply_default_scope
+      default_scope { where(self.quoted_table_name + ".#{paranoia_column} IS NULL") }
+    end
 
     before_restore {
       self.class.notify_observers(:before_restore, self) if self.class.respond_to?(:notify_observers)


### PR DESCRIPTION
Hi,

This option allows to handle a case when one wants deleted associations be still findable even if  they are deleted. Very useful for hiding unneeded records without breaking a logic of other associated models.
