### PR TITLE
Add :recursive option on #restore! to restore associations

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -19,11 +19,11 @@ module Paranoia
     end
     alias :deleted :only_deleted
 
-    def restore(id)
+    def restore(id, opts = {})
       if id.is_a?(Array)
-        id.map { |one_id| restore(one_id) }
+        id.map { |one_id| restore(one_id, opts) }
       else
-        only_deleted.find(id).restore!
+        only_deleted.find(id).restore!(opts)
       end
     end
   end
@@ -55,8 +55,13 @@ module Paranoia
     delete_or_soft_delete
   end
 
-  def restore!
-    run_callbacks(:restore) { update_column paranoia_column, nil }
+  def restore!(opts = {})
+    ActiveRecord::Base.transaction do
+      run_callbacks(:restore) do
+        update_column paranoia_column, nil
+        restore_associated_records if opts[:recursive]
+      end
+    end
   end
   alias :restore :restore!
 
@@ -81,6 +86,22 @@ module Paranoia
       with_transaction_returning_status { touch(paranoia_column) }
     else
       touch(paranoia_column)
+    end
+  end
+
+  # restore associated records that have been soft deleted when
+  # we called #destroy
+  def restore_associated_records
+    destroyed_associations = self.class.reflect_on_all_associations.select do |association|
+      association.options[:dependent] == :destroy
+    end
+
+    destroyed_associations.each do |association|
+      association = send(association.name)
+
+      if association.paranoid?
+        association.only_deleted.each { |record| record.restore(:recursive => true) }
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request adds a `recursive` option to the `#restore!` and `.restore` methods so associated records (that were soft deleted) will be restored too when we restore the record they belong to.

``` ruby
class User < ActiveRecord::Base
  acts_as_paranoid
  has_many :comments, dependent: :destroy
end

class Comment < ActiveRecord::Base
  acts_as_paranoid
  belongs_to :user
end

user = User.create
3.times { user.comments.create }

user.destroy
user.destroyed? # => true
user.comments.count? # => 0

user.restore! :recursive => true
user.destroyed? # => false
user.comments.count # => 3
```
