### PR TITLE
Add never delete option to rails 3 paranoia

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -75,6 +75,7 @@ module Paranoia
   # select and exec delete or soft-delete.
   # @param with_transaction [Boolean] exec with ActiveRecord Transactions, when soft-delete.
   def delete_or_soft_delete(with_transaction=false)
+    return touch_paranoia_column(with_transaction) if never_delete
     destroyed? ? destroy! : touch_paranoia_column(with_transaction)
   end
 
@@ -112,7 +113,9 @@ class ActiveRecord::Base
     alias :delete! :delete
     include Paranoia
     class_attribute :paranoia_column
+    class_attribute :never_delete
 
+    self.never_delete = options.fetch(:never_delete) { false }
     self.paranoia_column = options[:column] || :deleted_at
     default_scope { where(self.quoted_table_name + ".#{paranoia_column} IS NULL") }
 


### PR DESCRIPTION
The default behavior of for `#destroy` will delete a record if it's called twice. It seems a bit silly for `#destroy`'s behavior to change based on the number of calls, but alas that has become the accepted default.

I've added a `:never_delete` option that will make it so `#destroy` never actually deletes a record from the DB. So `#destroy` will update the paranoia column and that's it.

I'm open for changing the `:never_delete` name to match with the paranoia abstraction.. maybe `:uber_paranoid` or something.

Any :thought_balloon:s?
