### PR TITLE
destroy! now once again calls destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Paranoia is a re-implementation of [acts\_as\_paranoid](http://github.com/techno
 
 You would use either plugin / gem if you wished that when you called `destroy` on an Active Record object that it didn't actually destroy it, but just "hid" the record. Paranoia does this by setting a `deleted_at` field to the current time when you `destroy` a record, and hides it by scoping all queries on your model to only include records which do not have a `deleted_at` field.
 
-If you wish to actually destroy an object you may call destroy! on it or simply call destroy twice on the same object.
+If you wish to actually destroy an object you may call `really_destroy!`.
 
 ## Installation & Usage
 
@@ -75,11 +75,11 @@ Hey presto, it's there! Calling `destroy` will now set the `deleted_at` column:
 >> client.deleted_at => [current timestamp]
 ```
 
-If you really want it gone *gone*, call `destroy!`
+If you really want it gone *gone*, call `really_destroy!`
 
 ```
 >> client.deleted_at => nil
->> client.destroy! => client
+>> client.real_destroy! => client
 ```
 
 If you want a method to be called on destroy, simply provide a `before_destroy` callback:

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -99,8 +99,8 @@ end
 
 class ActiveRecord::Base
   def self.acts_as_paranoid(options={})
-    alias :ar_destroy :destroy
-    alias :destroy! :ar_destroy
+    alias :really_destroy! :destroy
+    alias :destroy! :destroy
     alias :delete! :delete
     include Paranoia
     class_attribute :paranoia_column


### PR DESCRIPTION
This is because destroy! is called by :dependent => :destroy association definitions (yes, destroy! and not destroy), which means that associated records of a paranoid object would suddenly go missing... making it very hard to restore them!

So instead, it's now called really_destroy! and destroy! is just an alias for destroy once again.

/cc @huoxito
