### PR TITLE
Improved behavior of restore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pkg/*
 tmp
 .rvmrc
 Gemfile.lock
+.project

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -336,7 +336,7 @@ class ParanoiaTest < Test::Unit::TestCase
     assert_equal true, second_child.destroyed?
   end
 
-  def test_do_not_restore_model_that_was_destroyed_before_parent_destroyed.
+  def test_do_not_restore_model_that_was_destroyed_before_parent_destroyed
     parent = ParentModel.create
     first_child = parent.dependent_models.create
     second_child = parent.dependent_models.create


### PR DESCRIPTION
Hello.

I'm afraid my expressions may be rude or hard to read, because I'm not so good at English.

When use restore!(:recursive => true), all associations are restored.
Even if model who destroyed before parent is destroyed, restored.
For example,

``` ruby
class ParentModel < ActiveRecord::Base
  has_many :child_models, dependent: :destroy
end

class ChildModel < ActiveRecord::Base
  acts_as_paranoid
  belongs_to :parent_model
end
```

When call restore!, The changes as follows.

``` ruby
parent  = ParentModel.create
first      = parent.child_models.create
second = parent.child_models.create

first.destroy
# first => destroyed

parent.destroy
# parent => destroyed, second => destroyed

parent.restore!(:recursive => true)
# parent => restored, second => restored,  and ... first => restored

```

This pr improved behavior of restore.
If child model has a dependent_delete column(*modifiable), dependent_delete has a info of 'deleted by dependence'. restore method see it.

``` sh
rails g add_dependent_delete_to_child_models dependent_delete:boolean
```

dependent_delete column is modifiable.

``` ruby
acts_as_paranoid dependent_column: dependent_destroyed
```

When call restore!, The changes as follows.

``` ruby
parent  = ParentModel.new
first      = parent.child_models.create
second = parent.child_models.create

first.destroy
# first => destroyed

parent.destroy
# parent => destroyed, second => destroyed

parent.restore!(:recursive => true)
# parent => restored, second => restored

```

In addition, do i have to be send pullrequest for branch of rails4.
