### PR TITLE
Fix destroy return value.

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -47,7 +47,8 @@ module Paranoia
   end
 
   def destroy
-    run_callbacks(:destroy) { touch_paranoia_column(true) }
+    callbacks_result = run_callbacks(:destroy) { touch_paranoia_column(true) }
+    callbacks_result ? self : false
   end
 
   def delete

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -13,6 +13,7 @@ ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_models (id INTEGER 
 ActiveRecord::Base.connection.execute 'CREATE TABLE featureful_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME, name VARCHAR(32))'
 ActiveRecord::Base.connection.execute 'CREATE TABLE plain_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE callback_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE fail_callback_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE related_models (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER NOT NULL, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE employers (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE employees (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
@@ -250,6 +251,20 @@ class ParanoiaTest < Test::Unit::TestCase
     assert_equal 1, ParanoidModel.unscoped.where(id: model.id).count
   end
 
+  def test_destroy_return_value_on_success
+    model = ParanoidModel.create
+    return_value = model.destroy
+
+    assert_equal(return_value, model)
+  end
+
+  def test_destroy_return_value_on_failure
+    model = FailCallbackModel.create
+    return_value = model.destroy
+
+    assert_equal(return_value, false)
+  end
+
   def test_restore_behavior_for_callbacks
     model = CallbackModel.new
     model.save
@@ -366,6 +381,13 @@ end
 class ParanoidModel < ActiveRecord::Base
   belongs_to :parent_model
   acts_as_paranoid
+end
+
+class FailCallbackModel < ActiveRecord::Base
+  belongs_to :parent_model
+  acts_as_paranoid
+
+  before_destroy { |_| false }
 end
 
 class FeaturefulModel < ActiveRecord::Base


### PR DESCRIPTION
Rails normally returns the model on successful destroy and false if any
callback fails.
