### PR TITLE
Recovery window

### DIFF
--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -350,6 +350,29 @@ class ParanoiaTest < Test::Unit::TestCase
     assert_equal true, second_child.destroyed?
   end
 
+  def test_restore_with_associations_with_recovery_window
+    parent = ParentModel.create
+    first_child = parent.very_related_models.create
+    second_child = parent.very_related_models.create
+
+    first_child.deleted_at = 1.year.ago
+    first_child.save
+
+    assert_equal true, parent.deleted_at.nil?
+    assert_equal false, first_child.deleted_at.nil?
+    assert_equal true, second_child.deleted_at.nil?
+
+    parent.destroy
+    assert_equal false, parent.deleted_at.nil?
+    assert_equal false, first_child.reload.deleted_at.nil?
+    assert_equal false, second_child.reload.deleted_at.nil?
+
+    parent.restore!(:recursive => true, :dependent_recovery_window => 1.minute)
+    assert_equal true, parent.deleted_at.nil?
+    assert_equal false, first_child.reload.deleted_at.nil?
+    assert_equal true, second_child.reload.deleted_at.nil?
+  end
+
   def test_observers_notified
     a = ParanoidModelWithObservers.create
     a.destroy


### PR DESCRIPTION
Added a recovery window to restore associated records that were deleted within a certain timespan of a parent object deletion.

This is mimicking similar behavior in [acts_as_paranoid](https://github.com/goncalossilva/acts_as_paranoid) that we needed.
