### PR TITLE
Fixes an exception when a has_one association is recursively restored.

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -103,10 +103,14 @@ module Paranoia
     end
 
     destroyed_associations.each do |association|
-      association = send(association.name)
+      association_data = send(association.name)
 
-      if association.paranoid?
-        association.only_deleted.each { |record| record.restore(:recursive => true) }
+      if association_data.paranoid?
+        if association.collection?
+          association_data.only_deleted.each { |record| record.restore(:recursive => true) }
+        else
+          association_data.restore(:recursive => true)
+        end
       end
     end
   end


### PR DESCRIPTION
The original implementation would raise a `method_missing` exception when a has_one association was recursively restored. The pull request first checks to see if the association is a collection before looping through the deleted items.
