### PR TITLE
hasOne association could not restore

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -114,6 +114,10 @@ module Paranoia
           end
         end
       end
+
+      if association_data.nil? && association.macro.to_s == "has_one"
+        Object.const_get(association.name.to_s.camelize).only_deleted.where("#{self.class.name.to_s.underscore}_id", self.id).first.try(:restore, recursive: true)
+      end
     end
   end
 end

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -123,7 +123,9 @@ module Paranoia
       end
 
       if association_data.nil? && association.macro.to_s == "has_one"
-        Object.const_get(association.name.to_s.camelize).only_deleted.where("#{self.class.name.to_s.underscore}_id", self.id).first.try(:restore, recursive: true)
+        association_class_name = association.options[:class_name].present? ? association.options[:class_name] : association.name.to_s.camelize
+        association_foreign_key = association.options[:foreign_key].present? ? association.options[:foreign_key] : "#{self.class.name.to_s.underscore}_id"
+        Object.const_get(association_class_name).only_deleted.where(association_foreign_key, self.id).first.try(:restore, recursive: true)
       end
     end
   end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -387,6 +387,47 @@ class ParanoiaTest < test_framework
     assert ParanoidModelWithBelong.with_deleted.reload.count != 0, "There should be a record"
   end
 
+  def test_new_restore_with_has_one_association
+    # setup and destroy test objects
+    hasOne = ParanoidModelWithHasOne.create
+    belongsTo = ParanoidModelWithBelong.create
+    hasOne.paranoid_model_with_belong = belongsTo
+    hasOne.save!
+
+    hasOne.destroy
+    assert_equal false, hasOne.deleted_at.nil?
+    assert_equal false, belongsTo.deleted_at.nil?
+
+    # Does it restore has_one associations?
+    newHasOne = ParanoidModelWithHasOne.with_deleted.find(hasOne.id)
+    newHasOne.restore(:recursive => true)
+    newHasOne.save!
+
+    assert_equal true, hasOne.reload.deleted_at.nil?
+    assert_equal true, belongsTo.reload.deleted_at.nil?, "#{belongsTo.deleted_at}"
+    assert ParanoidModelWithBelong.with_deleted.reload.count != 0, "There should be a record"
+  end
+
+  def test_model_restore_with_has_one_association
+    # setup and destroy test objects
+    hasOne = ParanoidModelWithHasOne.create
+    belongsTo = ParanoidModelWithBelong.create
+    hasOne.paranoid_model_with_belong = belongsTo
+    hasOne.save!
+
+    hasOne.destroy
+    assert_equal false, hasOne.deleted_at.nil?
+    assert_equal false, belongsTo.deleted_at.nil?
+
+    # Does it restore has_one associations?
+    ParanoidModelWithHasOne.restore(hasOne.id, :recursive => true)
+    hasOne.save!
+
+    assert_equal true, hasOne.reload.deleted_at.nil?
+    assert_equal true, belongsTo.reload.deleted_at.nil?, "#{belongsTo.deleted_at}"
+    assert ParanoidModelWithBelong.with_deleted.reload.count != 0, "There should be a record"
+  end
+
   def test_restore_with_nil_has_one_association
     # setup and destroy test object
     hasOne = ParanoidModelWithHasOne.create

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -13,6 +13,8 @@ ActiveRecord::Base.establish_connection :adapter => 'sqlite3', database: ':memor
 ActiveRecord::Base.connection.execute 'CREATE TABLE parent_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_models (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_model_with_belongs (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, deleted_at DATETIME, paranoid_model_with_has_one_id INTEGER)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_model_with_anthor_class_name_belongs (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, deleted_at DATETIME, paranoid_model_with_has_one_id INTEGER)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_model_with_foreign_key_belongs (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, deleted_at DATETIME, has_one_foreign_key_id INTEGER)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE featureful_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME, name VARCHAR(32))'
 ActiveRecord::Base.connection.execute 'CREATE TABLE plain_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE callback_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
@@ -397,7 +399,11 @@ class ParanoiaTest < test_framework
     # setup and destroy test objects
     hasOne = ParanoidModelWithHasOne.create
     belongsTo = ParanoidModelWithBelong.create
+    anthorClassName = ParanoidModelWithAnthorClassNameBelong.create
+    foreignKey = ParanoidModelWithForeignKeyBelong.create
     hasOne.paranoid_model_with_belong = belongsTo
+    hasOne.class_name_belong = anthorClassName
+    hasOne.paranoid_model_with_foreign_key_belong = foreignKey
     hasOne.save!
 
     hasOne.destroy
@@ -411,13 +417,19 @@ class ParanoiaTest < test_framework
     assert_equal true, hasOne.reload.deleted_at.nil?
     assert_equal true, belongsTo.reload.deleted_at.nil?, "#{belongsTo.deleted_at}"
     assert ParanoidModelWithBelong.with_deleted.reload.count != 0, "There should be a record"
+    assert ParanoidModelWithAnthorClassNameBelong.with_deleted.reload.count != 0, "There should be an other record"
+    assert ParanoidModelWithForeignKeyBelong.with_deleted.reload.count != 0, "There should be a foreign_key record"
   end
 
   def test_new_restore_with_has_one_association
     # setup and destroy test objects
     hasOne = ParanoidModelWithHasOne.create
     belongsTo = ParanoidModelWithBelong.create
+    anthorClassName = ParanoidModelWithAnthorClassNameBelong.create
+    foreignKey = ParanoidModelWithForeignKeyBelong.create
     hasOne.paranoid_model_with_belong = belongsTo
+    hasOne.class_name_belong = anthorClassName
+    hasOne.paranoid_model_with_foreign_key_belong = foreignKey
     hasOne.save!
 
     hasOne.destroy
@@ -432,13 +444,19 @@ class ParanoiaTest < test_framework
     assert_equal true, hasOne.reload.deleted_at.nil?
     assert_equal true, belongsTo.reload.deleted_at.nil?, "#{belongsTo.deleted_at}"
     assert ParanoidModelWithBelong.with_deleted.reload.count != 0, "There should be a record"
+    assert ParanoidModelWithAnthorClassNameBelong.with_deleted.reload.count != 0, "There should be an other record"
+    assert ParanoidModelWithForeignKeyBelong.with_deleted.reload.count != 0, "There should be a foreign_key record"
   end
 
   def test_model_restore_with_has_one_association
     # setup and destroy test objects
     hasOne = ParanoidModelWithHasOne.create
     belongsTo = ParanoidModelWithBelong.create
+    anthorClassName = ParanoidModelWithAnthorClassNameBelong.create
+    foreignKey = ParanoidModelWithForeignKeyBelong.create
     hasOne.paranoid_model_with_belong = belongsTo
+    hasOne.class_name_belong = anthorClassName
+    hasOne.paranoid_model_with_foreign_key_belong = foreignKey
     hasOne.save!
 
     hasOne.destroy
@@ -452,6 +470,8 @@ class ParanoiaTest < test_framework
     assert_equal true, hasOne.reload.deleted_at.nil?
     assert_equal true, belongsTo.reload.deleted_at.nil?, "#{belongsTo.deleted_at}"
     assert ParanoidModelWithBelong.with_deleted.reload.count != 0, "There should be a record"
+    assert ParanoidModelWithAnthorClassNameBelong.with_deleted.reload.count != 0, "There should be an other record"
+    assert ParanoidModelWithForeignKeyBelong.with_deleted.reload.count != 0, "There should be a foreign_key record"
   end
 
   def test_restore_with_nil_has_one_association
@@ -592,9 +612,21 @@ end
 # refer back to regression test for #118
 class ParanoidModelWithHasOne < ParanoidModel
   has_one :paranoid_model_with_belong, :dependent => :destroy
+  has_one :class_name_belong, :dependent => :destroy, :class_name => "ParanoidModelWithAnthorClassNameBelong"
+  has_one :paranoid_model_with_foreign_key_belong, :dependent => :destroy, :foreign_key => "has_one_foreign_key_id"
 end
 
 class ParanoidModelWithBelong < ActiveRecord::Base
+  acts_as_paranoid
+  belongs_to :paranoid_model_with_has_one
+end
+
+class ParanoidModelWithAnthorClassNameBelong < ActiveRecord::Base
+  acts_as_paranoid
+  belongs_to :paranoid_model_with_has_one
+end
+
+class ParanoidModelWithForeignKeyBelong < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :paranoid_model_with_has_one
 end


### PR DESCRIPTION
When I find @pobocks fix the problem https://github.com/radar/paranoia/pull/119 , and I use the new paranoia and find another bug. 
The problem can look at my first commit what is a test and the problem like https://github.com/radar/paranoia/issues/120 .
