### PR TITLE
Explicitly load AR unless already loaded

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -1,3 +1,5 @@
+require 'active_record' unless defined? ActiveRecord
+
 module Paranoia
   def self.included(klazz)
     klazz.extend Query


### PR DESCRIPTION
This fixes `uninitialized constant Paranoia::ActiveRecord` when using `paranoia` in a non-Rails application.
