### PR TITLE
Add rspec matcher: act_as_paranoid

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -150,3 +150,5 @@ class ActiveRecord::Base
     self.class.paranoia_column
   end
 end
+
+require 'paranoia/rspec' if defined? RSpec

--- a/lib/paranoia/rspec.rb
+++ b/lib/paranoia/rspec.rb
@@ -1,0 +1,9 @@
+require 'rspec/expectations'
+
+# Validate the subject's class did call "acts_as_paranoid"
+RSpec::Matchers.define :act_as_paranoid do
+  match { |subject| subject.class.ancestors.include?(Paranoia) }
+
+  failure_message_for_should { "#{subject.class} should use `acts_as_paranoid`" }
+  failure_message_for_should_not { "#{subject.class} should not use `acts_as_paranoid`" }
+end


### PR DESCRIPTION
This provides as RSpec matcher that can be used like this in models:

``` ruby
describe Model
  it { should act_as_paranoid }
end
```
