### PR TITLE
Adds #really_destroyed? method to work as default rails #destroyed?

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -117,6 +117,7 @@ end
 
 class ActiveRecord::Base
   def self.acts_as_paranoid(options={})
+    alias :really_destroyed? :destroyed?
     alias :ar_destroy :destroy
     alias :destroy! :ar_destroy
     alias :delete! :delete

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -102,6 +102,7 @@ class ParanoiaTest < Test::Unit::TestCase
     model.destroy
 
     assert_equal false, model.deleted_at.nil?
+    assert_equal false, model.really_destroyed?
 
     assert_equal 0, model.class.count
     assert_equal 1, model.class.unscoped.count
@@ -287,6 +288,14 @@ class ParanoiaTest < Test::Unit::TestCase
     model.destroy!
 
     assert_equal 0, ParanoidModel.unscoped.where(id: model.id).count
+  end
+
+  def test_really_destroyed
+    model = ParanoidModel.new
+    model.save
+    model.destroy!
+
+    assert model.really_destroyed?
   end
 
   def test_real_destroy_dependent_destroy


### PR DESCRIPTION
Paranoia gem reimplements `#destroyed?` method to check only `paranoia_column` presence. But sometimes we need to make sure record is going through real destroy process. 
For example if we have attached file and we want to destroy it only on real destroy:

``` ruby
after_destroy :remove_attachments, if: :really_destroyed?
```

New method `#really_destroyed?` added to check if model destroyed completely. 
