### PR TITLE
Add note about different behaviors of `recover` vs `restore`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ You can replace the older `acts_as_paranoid` methods as follows:
 |`find_with_deleted(:first)` | `Client.with_deleted.first`    |
 |`find_with_deleted(id)`     | `Client.with_deleted.find(id)` |
 
+The `recover` method in `acts_as_paranoid` runs `update` callbacks.  Paranoia's
+`restore` method does not do this.
+
 ## License
 
 This gem is released under the MIT license.


### PR DESCRIPTION
The `acts_as_paranoid` gem (v0.4.1) uses assignment followed by a call
to `#save` for restoring a record:

```
# in #recover
run_callbacks :recover do
  recover_dependent_associations(options[:recovery_window], options) if options[:recursive]

  self.paranoid_value = nil
  self.save
end
```

This runs any `update` callbacks as well as `recover` callbacks.

Paranoia uses `#update_column` instead of `#save`, so no `update`
callbacks are run when restoring a record.

With this commit the difference in behavior is described in the section
"Acts As Paranoid Migration" of the README.
