### PR TITLE
Allow destroying a non-persisted Paranoid object

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -111,6 +111,11 @@ module Paranoia
   # insert time to paranoia column.
   # @param with_transaction [Boolean] exec with ActiveRecord Transactions.
   def touch_paranoia_column(with_transaction=false)
+	  # Sometimes paranoid objects are created by has_one relationships; they are
+	  # never persisted to the database, so touching the column would raise an
+	  # exception from ActiveRecord.
+	  return unless persisted?
+
     # This method is (potentially) called from really_destroy
     # The object the method is being called on may be frozen
     # Let's not touch it if it's frozen.

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -111,10 +111,10 @@ module Paranoia
   # insert time to paranoia column.
   # @param with_transaction [Boolean] exec with ActiveRecord Transactions.
   def touch_paranoia_column(with_transaction=false)
-	  # Sometimes paranoid objects are created by has_one relationships; they are
-	  # never persisted to the database, so touching the column would raise an
-	  # exception from ActiveRecord.
-	  return unless persisted?
+    # Sometimes paranoid objects are created by has_one relationships; they are
+    # never persisted to the database, so touching the column would raise an
+    # exception from ActiveRecord.
+    return unless persisted?
 
     # This method is (potentially) called from really_destroy
     # The object the method is being called on may be frozen

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -203,10 +203,10 @@ class ParanoiaTest < test_framework
   end
 
   def test_destroy_behaviour_for_unpersisted_models
-		model = ParanoidModel.new
-		model.destroy
+    model = ParanoidModel.new
+    model.destroy
 
-		# No assertion because we just want to ensure that ActiveRecord does not complain.
+    # No assertion because we just want to ensure that ActiveRecord does not complain.
   end
 
   # Regression test for #24

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -202,6 +202,13 @@ class ParanoiaTest < test_framework
     assert_equal 1, model.class.unscoped.count
   end
 
+  def test_destroy_behaviour_for_unpersisted_models
+		model = ParanoidModel.new
+		model.destroy
+
+		# No assertion because we just want to ensure that ActiveRecord does not complain.
+  end
+
   # Regression test for #24
   def test_chaining_for_paranoid_models
     scope = FeaturefulModel.where(:name => "foo").only_deleted


### PR DESCRIPTION
Currently destruction is made via touching the paranoid column. This works unless the object being destroyed has not yet been persisted, such as when replacing the other end of a has_one relation. There is no need to mark it destroyed in that scenario because it will not be stored in database.
