### PR TITLE
Update paranoia_test.rb

### DIFF
--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -420,9 +420,8 @@ class ParanoiaTest < test_framework
     assert_equal false, hasOne.reload.deleted_at.nil?
 
     # Does it raise NoMethodException on restore of nil
-    assert_nothing_raised do
-      hasOne.restore(:recursive => true)
-    end
+    hasOne.restore(:recursive => true)
+    
     assert hasOne.reload.deleted_at.nil?
   end
 


### PR DESCRIPTION
Deprecated minitest method assert_nothing_raised was blowing up on travis. 

Removed deprecated assert_nothing_raised from test.
