### PR TITLE
Allow rails 3.1

### DIFF
--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project = 'paranoia'
 
-  s.add_dependency 'activerecord', '~> 3.2'
+  s.add_dependency 'activerecord', '~> 3.1'
 
   s.add_development_dependency 'bundler', '>= 1.0.0'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
So the tests on rails3 don't pass at all (including on 3.2), but the same tests fail on 3.1 and 3.2.

Unfortunately, the latest version of this gem available for 3.1 suffers from https://github.com/radar/paranoia/issue/81. This patch will make fix that issue for rails 3.1 apps.
