### PR TITLE
Add optional sentinel_value

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,44 +182,6 @@ You can replace the older `acts_as_paranoid` methods as follows:
 The `recover` method in `acts_as_paranoid` runs `update` callbacks.  Paranoia's
 `restore` method does not do this.
 
-## Support for Unique Keys with Null Values
-
-With most databases, a unique key containing a null value will not be enforced because the null value is unique per row.
-
-``` ruby
-class AddDeletedAtToClients < ActiveRecord::Migration
-  def change
-    add_column :clients, :deleted_at, :datetime
-    add_index :clients, [:username, :deleted_at], unique: true
-  end
-end
-```
-
-Given the migration above, you could have multiple users with username bob given the following inserts: ('bob', null), ('bob', null), ('bob', null). We can agree this is not the expected behavior.
-
-To avoid this problem, we could use a flag column instead of a datetime, but the datetime value has intrinsic usefulness.  Instead, we can add a second column for the unique key that always has a value, in this case 0 or 1:
-
-``` ruby
-class AddDeletedAtToClients < ActiveRecord::Migration
-  def change
-    add_column :clients, :deleted_at, :datetime
-    add_column :clients, :is_deleted, :boolean, null: false, default: 0
-    add_index :clients, [:username, :is_deleted], unique: true
-  end
-end
-```
-
-Support this new column by updating your model as such:
-
-``` ruby
-class Client < ActiveRecord::Base
-  acts_as_paranoid :flag_column => :is_deleted
-  ...
-end
-```
-
-If you create an index on the flag column, and you want paranoia to use that index instead of deleted_at, you can add `:index_column => :is_deleted` to the acts_as_paranoid definition.
-
 ## License
 
 This gem is released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,27 @@ You can replace the older `acts_as_paranoid` methods as follows:
 The `recover` method in `acts_as_paranoid` runs `update` callbacks.  Paranoia's
 `restore` method does not do this.
 
+## Support for Unique Keys with Null Values
+
+Most databases ignore null columns when it comes to resolving unique index
+constraints.  This means unique constraints that involve nullable columns may be
+problematic. Instead of using `NULL` to represent a not-deleted row, you can pick
+a value that you want paranoia to mean not deleted. Note that you can/should
+now apply a `NOT NULL` constraint to your `deleted_at` column.
+
+Per model:
+
+```ruby
+# pick some value
+acts_as_paranoid sentinel_value: DateTime.new(0)
+```
+
+or globally in a rails initializer, e.g. `config/initializer/paranoia.rb`
+
+```ruby
+Paranoia.default_sentinel_value = DateTime.new(0)
+```
+
 ## License
 
 This gem is released under the MIT license.

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -11,14 +11,14 @@ module Paranoia
 
     def with_deleted
       if ActiveRecord::VERSION::STRING >= "4.1"
-        unscope where: paranoia_indexed_column
+        unscope where: paranoia_column
       else
         all.tap { |x| x.default_scoped = false }
       end
     end
 
     def only_deleted
-      with_deleted.where.not(paranoia_indexed_column => paranoia_false_value)
+      with_deleted.where.not(paranoia_column => nil)
     end
     alias :deleted :only_deleted
 
@@ -28,12 +28,6 @@ module Paranoia
       else
         only_deleted.find(id).restore!(opts)
       end
-    end
-
-    private
-
-    def paranoia_false_value
-      (paranoia_indexed_column == paranoia_column) ? nil : 0
     end
   end
 
@@ -83,7 +77,6 @@ module Paranoia
     self.class.transaction do
       run_callbacks(:restore) do
         update_column paranoia_column, nil
-        update_column(paranoia_flag_column, false) if paranoia_flag_column
         restore_associated_records if opts[:recursive]
       end
     end
@@ -97,12 +90,7 @@ module Paranoia
 
   private
 
-  def mark_columns_deleted
-    update_column(paranoia_flag_column, true) if paranoia_flag_column
-    touch(paranoia_column)
-  end
-
-  # touch paranoia column, update flag column if necessary
+  # touch paranoia column.
   # insert time to paranoia column.
   # @param with_transaction [Boolean] exec with ActiveRecord Transactions.
   def touch_paranoia_column(with_transaction=false)
@@ -111,11 +99,9 @@ module Paranoia
     # Let's not touch it if it's frozen.
     unless self.frozen?
       if with_transaction
-        with_transaction_returning_status do
-          mark_columns_deleted
-        end
+        with_transaction_returning_status { touch(paranoia_column) }
       else
-        mark_columns_deleted
+        touch(paranoia_column)
       end
     end
   end
@@ -170,13 +156,9 @@ class ActiveRecord::Base
 
     include Paranoia
     class_attribute :paranoia_column
-    class_attribute :paranoia_flag_column
-    class_attribute :paranoia_indexed_column
 
     self.paranoia_column = options[:column] || :deleted_at
-    self.paranoia_flag_column = options[:flag_column] || nil
-    self.paranoia_indexed_column = options[:indexed_column] || paranoia_column
-    default_scope { where(paranoia_indexed_column => paranoia_false_value) }
+    default_scope { where(paranoia_column => nil) }
 
     before_restore {
       self.class.notify_observers(:before_restore, self) if self.class.respond_to?(:notify_observers)
@@ -208,14 +190,6 @@ class ActiveRecord::Base
   end
 
   private
-
-  def paranoia_flag_column
-    self.class.paranoia_flag_column
-  end
-
-  def paranoia_indexed_column
-    self.class.paranoia_indexed_column
-  end
 
   def paranoia_column
     self.class.paranoia_column

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -1,6 +1,17 @@
 require 'active_record' unless defined? ActiveRecord
 
 module Paranoia
+  @@default_sentinel_value = nil
+
+  # Change default_sentinel_value in a rails initilizer
+  def self.default_sentinel_value=(val)
+    @@default_sentinel_value = val
+  end
+
+  def self.default_sentinel_value
+    @@default_sentinel_value
+  end
+
   def self.included(klazz)
     klazz.extend Query
     klazz.extend Callbacks
@@ -18,7 +29,7 @@ module Paranoia
     end
 
     def only_deleted
-      with_deleted.where.not(paranoia_column => nil)
+      with_deleted.where.not(paranoia_column => paranoia_sentinel_value)
     end
     alias :deleted :only_deleted
 
@@ -76,7 +87,7 @@ module Paranoia
   def restore!(opts = {})
     self.class.transaction do
       run_callbacks(:restore) do
-        update_column paranoia_column, nil
+        update_column paranoia_column, paranoia_sentinel_value
         restore_associated_records if opts[:recursive]
       end
     end
@@ -84,7 +95,7 @@ module Paranoia
   alias :restore :restore!
 
   def destroyed?
-    !!send(paranoia_column)
+    send(paranoia_column) != paranoia_sentinel_value
   end
   alias :deleted? :destroyed?
 
@@ -155,10 +166,11 @@ class ActiveRecord::Base
     end
 
     include Paranoia
-    class_attribute :paranoia_column
+    class_attribute :paranoia_column, :paranoia_sentinel_value
 
     self.paranoia_column = options[:column] || :deleted_at
-    default_scope { where(paranoia_column => nil) }
+    self.paranoia_sentinel_value = options.fetch(:sentinel_value) { Paranoia.default_sentinel_value }
+    default_scope { where(paranoia_column => paranoia_sentinel_value) }
 
     before_restore {
       self.class.notify_observers(:before_restore, self) if self.class.respond_to?(:notify_observers)
@@ -193,6 +205,10 @@ class ActiveRecord::Base
 
   def paranoia_column
     self.class.paranoia_column
+  end
+
+  def paranoia_sentinel_value
+    self.class.paranoia_sentinel_value
   end
 end
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -24,6 +24,7 @@ def connect!
   ActiveRecord::Base.connection.execute 'CREATE TABLE employees (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE jobs (id INTEGER NOT NULL PRIMARY KEY, employer_id INTEGER NOT NULL, employee_id INTEGER NOT NULL, deleted_at DATETIME)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE custom_column_models (id INTEGER NOT NULL PRIMARY KEY, destroyed_at DATETIME)'
+  ActiveRecord::Base.connection.execute 'CREATE TABLE custom_sentinel_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME NOT NULL)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE non_paranoid_models (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER)'
 end
 
@@ -156,6 +157,36 @@ class ParanoiaTest < test_framework
     assert_equal 1, model.class.unscoped.count
     assert_equal 1, model.class.only_deleted.count
     assert_equal 1, model.class.deleted.count
+  end
+
+  def test_default_sentinel_value
+    assert_equal nil, ParanoidModel.paranoia_sentinel_value
+  end
+
+  def test_sentinel_value_for_custom_sentinel_models
+    model = CustomSentinelModel.new
+    assert_equal 0, model.class.count
+    model.save!
+    assert_equal DateTime.new(0), model.deleted_at
+    assert_equal 1, model.class.count
+    model.destroy
+
+    assert DateTime.new(0) != model.deleted_at
+    assert model.destroyed?
+
+    assert_equal 0, model.class.count
+    assert_equal 1, model.class.unscoped.count
+    assert_equal 1, model.class.only_deleted.count
+    assert_equal 1, model.class.deleted.count
+
+    model.restore
+    assert_equal DateTime.new(0), model.deleted_at
+    assert !model.destroyed?
+
+    assert_equal 1, model.class.count
+    assert_equal 1, model.class.unscoped.count
+    assert_equal 0, model.class.only_deleted.count
+    assert_equal 0, model.class.deleted.count
   end
 
   def test_destroy_behavior_for_featureful_paranoid_models
@@ -585,6 +616,10 @@ end
 
 class CustomColumnModel < ActiveRecord::Base
   acts_as_paranoid column: :destroyed_at
+end
+
+class CustomSentinelModel < ActiveRecord::Base
+  acts_as_paranoid sentinel_value: DateTime.new(0)
 end
 
 class NonParanoidModel < ActiveRecord::Base


### PR DESCRIPTION
MySQL ignores null columns when it comes to resolving unique index constraints. This means that all of our unique constraints that involve nullable columns are problematic. This will allow the `deleted_at` value to be set globally or per model.

``` ruby
#pick some epoch
acts_as_paranoid sentinel_value: DateTime.new(0)
```

or globally in a rails initializer

`Paranoia.default_sentinel_value = DateTime.new(0)`
