### PR TITLE
 rails > 4.0.4 + rails 4.1 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ platforms :rbx do
   gem 'rubinius-developer_tools'
 end
 
-rails = ENV['RAILS'] || '~> 4.0.2'
+rails = ENV['RAILS'] || '~> 4.1.4'
 
 gem 'rails', rails
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -153,8 +153,10 @@ class ActiveRecord::Base
           # Paranoid models will have this method, non-paranoid models will not
           associated_records = associated_records.with_deleted if associated_records.respond_to?(:with_deleted)
           associated_records.each(&:really_destroy!)
+          self.send(name).reload
         end
       end
+      touch_paranoia_column if ActiveRecord::VERSION::STRING >= "4.1"
       destroy!
     end
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -144,7 +144,7 @@ class ActiveRecord::Base
     alias :destroy! :destroy
     alias :delete! :delete
     def really_destroy!
-      dependent_reflections = self.reflections.select do |name, reflection|
+      dependent_reflections = self.class.reflections.select do |name, reflection|
         reflection.options[:dependent] == :destroy
       end
       if dependent_reflections.any?

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -99,7 +99,7 @@ class ParanoiaTest < test_framework
     assert_equal nil, model.instance_variable_get(:@validate_called)
     assert_equal nil, model.instance_variable_get(:@destroy_callback_called)
     assert_equal nil, model.instance_variable_get(:@after_destroy_callback_called)
-    assert_equal nil, model.instance_variable_get(:@after_commit_callback_called)
+    assert model.instance_variable_get(:@after_commit_callback_called)
   end
 
   def test_destroy_behavior_for_paranoid_models


### PR DESCRIPTION
As of rails 4.0.4, touching a column will also fire the after_commit callback. rails changelog: https://github.com/rails/rails/blob/v4.0.4/activerecord/CHANGELOG.md ("Make touch fire the after_commit and after_rollback callbacks.") which means that one test is failing starting with rails 4.0.4.

In this pullrequest i just fixed the test, but I also want to raise the question: wouldn't it be better to work around using `touch`, so that delete no longer raises the `after_commit`callback? This would be nearer on the normal rails behaviour of having `delete` not firing any callbacks. As of now, `delete` also fires the `after_touch` callback, which might be surprising to some people.

I'd be glad to look into it, if people think that's worth doing.

Also, there are two fixes for rails 4.1
- starting with rails 4.1.0 `really_destroy!` only destroys already soft-deleted records, and soft-deletes "normal" records. fixed by calling `touch_paranoia_column` before calling `destroy!`. after calling `really_destroy!` on the dependent objects, i reload the associations on the object, otherwise ActiveRecords's `destroy!` will try to destroy the already really_destroyed associated objects that still exist on the object, but no longer in the database. this fixes #129
- in rails 4.1.2 the reflections have been reworked and `reflections` can no longer be called on activerecord objects, but only on the class (https://github.com/rails/rails/pull/15300). there's still `_reflections`but it's considered private.

Actually there should have been a separate pull request for the rails 4 issue and one for the rails 4.1 fixes, but i messed it up. Sorry, i'm quite new to the whole thing.

 Thanks for your feedback!
