### PR TITLE
Destroy multiple records with flag_column and unique keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,13 +193,13 @@ end
 
 Given the migration above, you could have multiple users with username bob given the following inserts: ('bob', null), ('bob', null), ('bob', null). We can agree this is not the expected behavior.
 
-To avoid this problem, we could use a flag column instead of a datetime, but the datetime value has intrinsic usefulness.  Instead, we can add a second column for the unique key that always has a value, in this case 0 or 1:
+To avoid this problem, we could use a flag column instead of a datetime, but the datetime value has intrinsic usefulness.  Instead, we can add a second column for the unique key that always has a value, in this case 0 or 1+:
 
 ``` ruby
 class AddDeletedAtToClients < ActiveRecord::Migration
   def change
     add_column :clients, :deleted_at, :datetime
-    add_column :clients, :is_deleted, :boolean, null: false, default: 0
+    add_column :clients, :is_deleted, :integer, null: false, default: 0
     add_index :clients, [:username, :is_deleted], unique: true
   end
 end

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -79,7 +79,7 @@ module Paranoia
     ActiveRecord::Base.transaction do
       run_callbacks(:restore) do
         update_column paranoia_column, nil
-        update_column(paranoia_flag_column, false) if paranoia_flag_column
+        update_column(paranoia_flag_column, 0) if paranoia_flag_column
         restore_associated_records if opts[:recursive]
       end
     end
@@ -94,7 +94,8 @@ module Paranoia
   private
 
   def mark_columns_deleted
-    update_column(paranoia_flag_column, true) if paranoia_flag_column
+    primary_id = self.send(self.class.primary_key)
+    update_column(paranoia_flag_column, primary_id) if paranoia_flag_column
     touch(paranoia_column)
   end
 


### PR DESCRIPTION
flag_column is a great idea.
However, I found that there is a problem with the case below.

---
1. Prepare a paranoia model with flag_column and unique keys.
   
   ``` ruby
   class AddDeletedAtToClients < ActiveRecord::Migration
     def change
       add_column :clients, :deleted_at, :datetime
       add_column :clients, :is_deleted, :boolean, null: false, default: 0
       add_index :clients, [:username, :is_deleted], unique: true
     end
   end
   ```
   
   ``` ruby
   class Client < ActiveRecord::Base
     acts_as_paranoid :flag_column => :is_deleted
     ...
   end
   ```
2. Create a record.
   { id: 1, username: 'bob', is_deleted: false }
3. Destroy the record.
   { id: 1, username: 'bob', is_deleted: true }
4. Create a new record with same username.
   { id: 2, username: 'bob', is_deleted: false }
5. Destroy the record. (SQL error)
   { id: 2, username: 'bob', is_deleted: true }
   
   ``` ruby
   #=> ActiveRecord::RecordNotUnique: SQLite3::ConstraintException: columns username, is_deleted are not unique: UPDATE "clients" SET "is_deleted" = 1 WHERE "clients"."id" = 2
   ```

---

I suggest a modification that update flag_colum by primary key when destroy record for this problem.
1. Change flag_column type to `integer` from `boolean`.
   
   ``` diff
   -    add_column :clients, :is_deleted, :boolean, null: false, default: 0
   +    add_column :clients, :is_deleted, :integer, null: false, default: 0
   ```
2. Create a record.
   { id: 1, username: 'bob', is_deleted: 0 }
3. Destroy the record.
   { id: 1, username: 'bob', is_deleted: 1 }
4. Create a new record with same username.
   { id: 2, username: 'bob', is_deleted: 0 }
5. Destroy the record. (succeed)
   { id: 2, username: 'bob', is_deleted: 2 }

---

I hope that you would consider.

# Please excuse my awful English...
