### PR TITLE
include AR callbacks in transaction when running destroy

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -56,7 +56,11 @@ module Paranoia
   end
 
   def destroy
-    callbacks_result = run_callbacks(:destroy) { touch_paranoia_column(true) }
+    callbacks_result = transaction do
+      run_callbacks(:destroy) do
+        touch_paranoia_column
+      end
+    end
     callbacks_result ? self : false
   end
 


### PR DESCRIPTION
According to https://github.com/rails/rails/blob/4-1-stable/activerecord/lib/active_record/transactions.rb#L78:

```
Both +save+ and +destroy+ come wrapped in a transaction that ensures
that whatever you do in validations or callbacks will happen under its
protected cover
```

acts_as_paranoid overrides the default destroy behavior, but does not currently emulate this transactional wrapping. This PR aims to restore that default AR behavior.

As an example, we have seen issues resulting from this problem manifest with `dependent: destroy` declarations. Sometimes, after a few dependent records are destroyed, something may go wrong and throw an exception before `run_callbacks` is complete and, thus, touch_paranoia_column is never triggered. This leaves the parent record active, but with deleted child records. Since default AR behavior would make this chain of events atomic, I would expect the same behavior with paranoia.
