### PR TITLE
Fix RSpec 3.x deprecations

### DIFF
--- a/lib/paranoia/rspec.rb
+++ b/lib/paranoia/rspec.rb
@@ -4,6 +4,6 @@ require 'rspec/expectations'
 RSpec::Matchers.define :act_as_paranoid do
   match { |subject| subject.class.ancestors.include?(Paranoia) }
 
-  failure_message { "#{subject.class} should use `acts_as_paranoid`" }
-  failure_message_when_negated { "#{subject.class} should not use `acts_as_paranoid`" }
+  failure_message { "expected #{subject.class} to use `acts_as_paranoid`" }
+  failure_message_when_negated { "expected #{subject.class} not to use `acts_as_paranoid`" }
 end

--- a/lib/paranoia/rspec.rb
+++ b/lib/paranoia/rspec.rb
@@ -4,6 +4,6 @@ require 'rspec/expectations'
 RSpec::Matchers.define :act_as_paranoid do
   match { |subject| subject.class.ancestors.include?(Paranoia) }
 
-  failure_message_for_should { "#{subject.class} should use `acts_as_paranoid`" }
-  failure_message_for_should_not { "#{subject.class} should not use `acts_as_paranoid`" }
+  failure_message { "#{subject.class} should use `acts_as_paranoid`" }
+  failure_message_when_negated { "#{subject.class} should not use `acts_as_paranoid`" }
 end

--- a/lib/paranoia/rspec.rb
+++ b/lib/paranoia/rspec.rb
@@ -6,4 +6,8 @@ RSpec::Matchers.define :act_as_paranoid do
 
   failure_message { "expected #{subject.class} to use `acts_as_paranoid`" }
   failure_message_when_negated { "expected #{subject.class} not to use `acts_as_paranoid`" }
+
+  # RSpec 2 compatibility:
+  alias_method :failure_message_for_should, :failure_message
+  alias_method :failure_message_for_should_not, :failure_message_when_negated
 end


### PR DESCRIPTION
The `failure_message_for_should` syntax is deprecated in RSpec 3.

This could of course be merged into the `rails3` branch as well. Do you want me to make a separate pull request for that?
