### PR TITLE
Added callback of really_destroy when its actually destroyed and association with_deleted to belongs_to.

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -17,6 +17,40 @@ module Paranoia
     klazz.extend Callbacks
   end
 
+  module Association
+    def self.included(base)
+      base.extend ClassMethods
+      class << base
+        alias_method_chain :belongs_to, :deleted
+      end
+    end
+
+    module ClassMethods
+
+      def belongs_to_with_deleted(target, scope = nil, options = {})
+        with_deleted = (scope.is_a?(Hash) ? scope : options).delete(:with_deleted)
+        result = belongs_to_without_deleted(target, scope, options)
+
+        if with_deleted
+          result[:with_deleted] = with_deleted
+          unless method_defined? "#{target}_with_unscoped"
+            class_eval <<-RUBY, __FILE__, __LINE__
+              def #{target}_with_unscoped(*args)
+                association = association(:#{target})
+                return nil if association.options[:polymorphic] && association.klass.nil?
+                return #{target}_without_unscoped(*args) unless association.klass.paranoid?
+                association.klass.with_deleted.scoping { #{target}_without_unscoped(*args) }
+              end
+              alias_method_chain :#{target}, :unscoped
+            RUBY
+          end
+        end
+
+        result
+      end
+    end
+  end
+
   module Query
     def paranoid? ; true ; end
 
@@ -166,7 +200,10 @@ module Paranoia
   end
 end
 
+
+
 class ActiveRecord::Base
+
   def self.acts_as_paranoid(options={})
     alias :destroy! :destroy
     alias :delete! :delete
@@ -241,5 +278,7 @@ class ActiveRecord::Base
     self.class.paranoia_sentinel_value
   end
 end
+
+ActiveRecord::Base.send :include, Paranoia::Association
 
 require 'paranoia/rspec' if defined? RSpec

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -361,7 +361,7 @@ class ParanoiaTest < test_framework
     assert model.instance_variable_get(:@destroy_callback_called)
     assert model.instance_variable_get(:@after_destroy_callback_called)
 
-    assert model.instance_variable_get(:@after_really_destroy_called)
+    assert model.instance_variable_get(:@really_destroy_called)
     assert model.instance_variable_get(:@after_really_destroy_called)
 
     refute CallbackModel.unscoped.exists?(model.id)

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -267,6 +267,14 @@ class ParanoiaTest < test_framework
     assert_equal 0, employer.employees.count
     assert_equal 0, employee.jobs.count
     assert_equal 0, employee.employers.count
+
+    employee3 = Employee.create
+    employer1 = Employer.create
+    job2 = NoJob.create :employer => employer, :employee => employee3
+    employee3.destroy
+    employer1.destroy
+    assert_equal employee3, job2.employee
+    assert_equal employer, job2.employer
   end
 
   def test_delete_behavior_for_callbacks
@@ -721,6 +729,12 @@ class Job < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :employer
   belongs_to :employee
+end
+
+class NoJob <  ActiveRecord::Base
+  self.table_name = 'jobs'
+  belongs_to :employer, with_deleted: true
+  belongs_to :employee, with_deleted: true
 end
 
 class CustomColumnModel < ActiveRecord::Base


### PR DESCRIPTION
Add a callback called "really_destroy" when the data is actually destroyed as even associations dependency the associated records of paranoid table are soft deleted and only destroyed callback is called. 

Added association with_deleted: true to belongs_to 
