### PR TITLE
Has one bug

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -144,7 +144,9 @@ module Paranoia
       if association_data.nil? && association.macro.to_s == "has_one"
         association_class_name = association.options[:class_name].present? ? association.options[:class_name] : association.name.to_s.camelize
         association_foreign_key = association.options[:foreign_key].present? ? association.options[:foreign_key] : "#{self.class.name.to_s.underscore}_id"
-        Object.const_get(association_class_name).only_deleted.where(association_foreign_key, self.id).first.try(:restore, recursive: true)
+        if Object.const_get(association_class_name).paranoid?
+          Object.const_get(association_class_name).only_deleted.where(association_foreign_key, self.id).first.try(:restore, recursive: true)
+        end
       end
     end
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -144,9 +144,7 @@ module Paranoia
       if association_data.nil? && association.macro.to_s == "has_one"
         association_class_name = association.options[:class_name].present? ? association.options[:class_name] : association.name.to_s.camelize
         association_foreign_key = association.options[:foreign_key].present? ? association.options[:foreign_key] : "#{self.class.name.to_s.underscore}_id"
-        if Object.const_get(association_class_name).paranoid?
-          Object.const_get(association_class_name).only_deleted.where(association_foreign_key, self.id).first.try(:restore, recursive: true)
-        end
+        Object.const_get(association_class_name).only_deleted.where(association_foreign_key, self.id).first.try(:restore, recursive: true) if Object.const_get(association_class_name).paranoid?
       end
     end
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -16,7 +16,7 @@ def connect!
   ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_model_with_belongs (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, deleted_at DATETIME, paranoid_model_with_has_one_id INTEGER)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_model_with_anthor_class_name_belongs (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, deleted_at DATETIME, paranoid_model_with_has_one_id INTEGER)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_model_with_foreign_key_belongs (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, deleted_at DATETIME, has_one_foreign_key_id INTEGER)'
-  ActiveRecord::Base.connection.execute 'CREATE TABLE not_paranoid_model_with_belongs (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, deleted_at DATETIME, paranoid_model_with_has_one_id INTEGER)'
+  ActiveRecord::Base.connection.execute 'CREATE TABLE not_paranoid_model_with_belongs (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, paranoid_model_with_has_one_id INTEGER)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE featureful_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME, name VARCHAR(32))'
   ActiveRecord::Base.connection.execute 'CREATE TABLE plain_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE callback_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
@@ -451,9 +451,12 @@ class ParanoiaTest < test_framework
     belongsTo = ParanoidModelWithBelong.create
     anthorClassName = ParanoidModelWithAnthorClassNameBelong.create
     foreignKey = ParanoidModelWithForeignKeyBelong.create
+    notParanoidModel = NotParanoidModelWithBelong.create
+
     hasOne.paranoid_model_with_belong = belongsTo
     hasOne.class_name_belong = anthorClassName
     hasOne.paranoid_model_with_foreign_key_belong = foreignKey
+    hasOne.not_paranoid_model_with_belong = notParanoidModel
     hasOne.save!
 
     hasOne.destroy
@@ -466,6 +469,7 @@ class ParanoiaTest < test_framework
 
     assert_equal true, hasOne.reload.deleted_at.nil?
     assert_equal true, belongsTo.reload.deleted_at.nil?, "#{belongsTo.deleted_at}"
+    assert_equal true, notParanoidModel.destroyed?
     assert ParanoidModelWithBelong.with_deleted.reload.count != 0, "There should be a record"
     assert ParanoidModelWithAnthorClassNameBelong.with_deleted.reload.count != 0, "There should be an other record"
     assert ParanoidModelWithForeignKeyBelong.with_deleted.reload.count != 0, "There should be a foreign_key record"
@@ -477,9 +481,12 @@ class ParanoiaTest < test_framework
     belongsTo = ParanoidModelWithBelong.create
     anthorClassName = ParanoidModelWithAnthorClassNameBelong.create
     foreignKey = ParanoidModelWithForeignKeyBelong.create
+    notParanoidModel = NotParanoidModelWithBelong.create
+
     hasOne.paranoid_model_with_belong = belongsTo
     hasOne.class_name_belong = anthorClassName
     hasOne.paranoid_model_with_foreign_key_belong = foreignKey
+    hasOne.not_paranoid_model_with_belong = notParanoidModel
     hasOne.save!
 
     hasOne.destroy
@@ -493,6 +500,7 @@ class ParanoiaTest < test_framework
 
     assert_equal true, hasOne.reload.deleted_at.nil?
     assert_equal true, belongsTo.reload.deleted_at.nil?, "#{belongsTo.deleted_at}"
+    assert_equal true, notParanoidModel.destroyed?
     assert ParanoidModelWithBelong.with_deleted.reload.count != 0, "There should be a record"
     assert ParanoidModelWithAnthorClassNameBelong.with_deleted.reload.count != 0, "There should be an other record"
     assert ParanoidModelWithForeignKeyBelong.with_deleted.reload.count != 0, "There should be a foreign_key record"
@@ -504,9 +512,12 @@ class ParanoiaTest < test_framework
     belongsTo = ParanoidModelWithBelong.create
     anthorClassName = ParanoidModelWithAnthorClassNameBelong.create
     foreignKey = ParanoidModelWithForeignKeyBelong.create
+    notParanoidModel = NotParanoidModelWithBelong.create
+
     hasOne.paranoid_model_with_belong = belongsTo
     hasOne.class_name_belong = anthorClassName
     hasOne.paranoid_model_with_foreign_key_belong = foreignKey
+    hasOne.not_paranoid_model_with_belong = notParanoidModel
     hasOne.save!
 
     hasOne.destroy
@@ -519,6 +530,7 @@ class ParanoiaTest < test_framework
 
     assert_equal true, hasOne.reload.deleted_at.nil?
     assert_equal true, belongsTo.reload.deleted_at.nil?, "#{belongsTo.deleted_at}"
+    assert_equal true, notParanoidModel.destroyed?
     assert ParanoidModelWithBelong.with_deleted.reload.count != 0, "There should be a record"
     assert ParanoidModelWithAnthorClassNameBelong.with_deleted.reload.count != 0, "There should be an other record"
     assert ParanoidModelWithForeignKeyBelong.with_deleted.reload.count != 0, "There should be a foreign_key record"


### PR DESCRIPTION
When the model of has_one association of the paranoid model is not a paranoid then it throws error because of with_deleted called on the association. 

Added a check of paranoid? before executing the query to restore has_one association. 
