### PR TITLE
Restoring has_one with recursive: true leads to ActiveRecord::StatementInvalid

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -144,7 +144,7 @@ module Paranoia
       if association_data.nil? && association.macro.to_s == "has_one"
         association_class_name = association.options[:class_name].present? ? association.options[:class_name] : association.name.to_s.camelize
         association_foreign_key = association.options[:foreign_key].present? ? association.options[:foreign_key] : "#{self.class.name.to_s.underscore}_id"
-        Object.const_get(association_class_name).only_deleted.where(association_foreign_key, self.id).first.try(:restore, recursive: true)
+        Object.const_get(association_class_name).only_deleted.where(association_foreign_key => self.id).first.try(:restore, recursive: true)
       end
     end
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -534,7 +534,25 @@ class ParanoiaTest < test_framework
     
     assert hasOne.reload.deleted_at.nil?
   end
-  
+
+  # covers #185
+  def test_restoring_recursive_has_one_restores_correct_object
+    hasOnes = 2.times.map { ParanoidModelWithHasOne.create }
+    belongsTos = 2.times.map { ParanoidModelWithBelong.create }
+    hasOnes.each_with_index { |ho, i| ho.update paranoid_model_with_belong: belongsTos[i] }
+    hasOnes.each { |ho| ho.destroy }
+
+    ParanoidModelWithHasOne.restore(hasOnes[1], :recursive => true)
+    hasOnes.each { |ho| ho.reload }
+    belongsTos.each { |bt| bt.reload }
+
+    # without #185, belongsTos[0] will be restored instead of belongsTos[1]
+    assert_equal false, hasOnes[0].deleted_at.nil?
+    assert_equal false, belongsTos[0].deleted_at.nil?
+    assert_equal true,  hasOnes[1].deleted_at.nil?
+    assert_equal true,  belongsTos[1].deleted_at.nil?
+  end
+
   # covers #131
   def test_has_one_really_destroy_with_nil
     model = ParanoidModelWithHasOne.create


### PR DESCRIPTION
i'm using paranoia with rails 4.1.5 and postgres. when trying to restore a record with a has_one association, activerecord will build an invalid query, e.g.

```
SELECT  "authors".* FROM "authors"  WHERE ("authors"."deleted_at" IS NOT NULL) AND (user_id)  ORDER BY "authors"."id" ASC LIMIT 1
```

as far as i understand it, the reason seems to be that the where call in `restore_associated_records` is not given a hash, but rather a string and the id. activerecord interprets this as raw sql and therefore creates the invalid `AND(user_id)`.

changing this to a hash fixes the problem in my app and does not raise any new errors with the test suite. btw, i can reproduce the error only in my app, and not with the test suite that ships with paranoia, i think it's because sqlite does not have a problem with such a query?
