### PR TITLE
Rename Paranoia#destroyed? to Paranoia#paranoia_destroyed?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ rvm:
 env:
   - RAILS='~> 4.0.8'
   - RAILS='~> 4.1.4'
+  - RAILS=master

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -71,7 +71,7 @@ module Paranoia
   # when they shouldn't
   if ActiveRecord::VERSION::STRING >= "4.1"
     def destroy!
-      destroyed? ? super : destroy || raise(ActiveRecord::RecordNotDestroyed)
+      paranoia_destroyed? ? super : destroy || raise(ActiveRecord::RecordNotDestroyed)
     end
   end
 
@@ -98,10 +98,10 @@ module Paranoia
   end
   alias :restore :restore!
 
-  def destroyed?
+  def paranoia_destroyed?
     send(paranoia_column) != paranoia_sentinel_value
   end
-  alias :deleted? :destroyed?
+  alias :deleted? :paranoia_destroyed?
 
   private
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -129,6 +129,13 @@ class ParanoiaTest < test_framework
     assert_equal 1, model.class.unscoped.count
   end
 
+  def test_update_columns_on_paranoia_destroyed
+    record = ParentModel.create
+    record.destroy
+
+    assert record.update_columns deleted_at: Time.now
+  end
+
   def test_scoping_behavior_for_paranoid_models
     parent1 = ParentModel.create
     parent2 = ParentModel.create
@@ -153,7 +160,7 @@ class ParanoiaTest < test_framework
     model.destroy
 
     assert_equal false, model.destroyed_at.nil?
-    assert model.destroyed?
+    assert model.paranoia_destroyed?
 
     assert_equal 0, model.class.count
     assert_equal 1, model.class.unscoped.count
@@ -174,7 +181,7 @@ class ParanoiaTest < test_framework
     model.destroy
 
     assert DateTime.new(0) != model.deleted_at
-    assert model.destroyed?
+    assert model.paranoia_destroyed?
 
     assert_equal 0, model.class.count
     assert_equal 1, model.class.unscoped.count
@@ -283,13 +290,13 @@ class ParanoiaTest < test_framework
     id = model.id
     model.destroy
 
-    assert model.destroyed?
+    assert model.paranoia_destroyed?
 
     model = ParanoidModel.only_deleted.find(id)
     model.restore!
     model.reload
 
-    assert_equal false, model.destroyed?
+    assert_equal false, model.paranoia_destroyed?
   end
 
   def test_restore_on_object_return_self
@@ -329,7 +336,7 @@ class ParanoiaTest < test_framework
     id = model.id
     model.destroy
 
-    assert model.destroyed?
+    assert model.paranoia_destroyed?
 
     model = CallbackModel.only_deleted.find(id)
     model.restore!
@@ -410,9 +417,9 @@ class ParanoiaTest < test_framework
     b.reload
     c.reload
 
-    refute a.destroyed?
-    assert b.destroyed?
-    refute c.destroyed?
+    refute a.paranoia_destroyed?
+    assert b.paranoia_destroyed?
+    refute c.paranoia_destroyed?
   end
 
   def test_restore_with_associations

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -9,6 +9,10 @@ else
 end
 require File.expand_path(File.dirname(__FILE__) + "/../lib/paranoia")
 
+if ActiveRecord::VERSION::STRING >= "4.2"
+  ActiveRecord::Base.raise_in_transactional_callbacks = true
+end
+
 def connect!
   ActiveRecord::Base.establish_connection :adapter => 'sqlite3', database: ':memory:'
   ActiveRecord::Base.connection.execute 'CREATE TABLE parent_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'


### PR DESCRIPTION
There was a change in ActiveRecord#update_columns on latest rails
so now it checks for `destroyed?` instead of `persisted?`. Paranoia
can't override `destoyed?` like this anymore otherwise
`update_columns` will always raise:

```
    ActiveRecord::ActiveRecordError: cannot update a destroyed record
```

see rails/rails@0f99aa6

@radar this is a breaking change so not sure how you want to handle it. Couldn't think of a fix other than renaming the method. I'm not sure why `destroyed?` was overridden here in the first place but if tests are missing a scenario this could break something else too. Let you know if I find anything new.
