### PR TITLE
Possible fix for 'cannot touch a new record object' error when using Shoulda Matchers

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -59,7 +59,7 @@ module Paranoia
   def destroy
     callbacks_result = transaction do
       run_callbacks(:destroy) do
-        touch_paranoia_column
+        touch_paranoia_column unless new_record?
       end
     end
     callbacks_result ? self : false

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -14,8 +14,10 @@ def connect!
   ActiveRecord::Base.connection.execute 'CREATE TABLE parent_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_models (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, deleted_at DATETIME)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_model_with_belongs (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, deleted_at DATETIME, paranoid_model_with_has_one_id INTEGER)'
+  ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_model_with_build_belongs (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, deleted_at DATETIME, paranoid_model_with_has_one_and_build_id INTEGER, name VARCHAR(32))'
   ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_model_with_anthor_class_name_belongs (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, deleted_at DATETIME, paranoid_model_with_has_one_id INTEGER)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_model_with_foreign_key_belongs (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, deleted_at DATETIME, has_one_foreign_key_id INTEGER)'
+  ActiveRecord::Base.connection.execute 'CREATE TABLE paranoid_model_with_has_one_and_builds (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER, color VARCHAR(32), deleted_at DATETIME, has_one_foreign_key_id INTEGER)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE featureful_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME, name VARCHAR(32))'
   ActiveRecord::Base.connection.execute 'CREATE TABLE plain_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE callback_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME)'
@@ -202,6 +204,11 @@ class ParanoiaTest < test_framework
 
     assert_equal 0, model.class.count
     assert_equal 1, model.class.unscoped.count
+  end
+
+  def test_destroy_behavior_for_has_one_with_build_and_validation_error
+    model = ParanoidModelWithHasOneAndBuild.create
+    model.destroy
   end
 
   # Regression test for #24
@@ -727,6 +734,23 @@ class ParanoidModelWithHasOne < ParanoidModel
   has_one :paranoid_model_with_belong, :dependent => :destroy
   has_one :class_name_belong, :dependent => :destroy, :class_name => "ParanoidModelWithAnthorClassNameBelong"
   has_one :paranoid_model_with_foreign_key_belong, :dependent => :destroy, :foreign_key => "has_one_foreign_key_id"
+end
+
+class ParanoidModelWithHasOneAndBuild < ActiveRecord::Base
+  has_one :paranoid_model_with_build_belong, :dependent => :destroy
+  validates :color, :presence => true
+  after_validation :build_paranoid_model_with_build_belong, on: :create
+
+  private
+  def build_paranoid_model_with_build_belong
+    super.tap { |child| child.name = "foo" }
+  end
+end
+
+class ParanoidModelWithBuildBelong < ActiveRecord::Base
+  acts_as_paranoid
+  validates :name, :presence => true
+  belongs_to :paranoid_model_with_has_one_and_build
 end
 
 class ParanoidModelWithBelong < ActiveRecord::Base


### PR DESCRIPTION
This could be super "edgy casey" and not in the scope of Paranoia, but maybe not. So here goes nothing:

If a parent model with a has_one relationship (dependent destroy) to a child model and some custom building logic for that child model, fails validation for some reason, I get some weird behavior when trying to call destroy on the parent, and subsequently the child. Specifically I get a `ActiveRecord::ActiveRecordError: cannot touch on a new record object` error in the parent model in regards to touching `deleted_at` in the child model.

I ran into this when trying to use Shoulda Matchers alongside Paranoia.

Take the following example:

``` ruby
#app/models/frowny_person.rb
class FrownyPerson < ActiveRecord::Base
  acts_as_paranoid
  has_one :face, dependent: :destroy
  validates :some_frowny_attr, presence: true
  after_validation :build_face, on: :create

  private
  def build_face
    super.tap { |face| face.some_face_attr = "In your face!" }
  end
end

#app/models/face.rb
class Face < ActiveRecord::Base
  acts_as_paranoid
  belongs_to :frowny_person
end

#spec/models/frowny_person_spec.rb
it { should validate_presence_of :some_frowny_attr }
```

From my understanding, what will happen is the Shoulda Matcher library will create a FrownyPerson instance, set the attribute in question to a blank value, and then run validations on it, and test the message it gets back. Where I get a bit fuzzy is, at some point, ActiveRecord will call `destroy` on the `Face` instance that `FrownyPerson` has built. I know it happens because `dependent: :destroy` is set, and I know it happens [here](https://github.com/rails/rails/blob/v4.1.7/activerecord/lib/active_record/associations/has_one_association.rb#L81), and when it does, it triggers all of Paranoia’s destroy logic. Since we are trying to destroy something that is in memory and not in the db yet, we end up trying to touch the `deleted_at` attribute of the `Face` instance, and that causes the error.

I was able to simulate this behavior in the test associated with this pull request, so if it helps, take a look there and let me know what you think.

Again, this case is kinda out there, but it may be relevant. 

Side note: I almost never write tests using Test::Unit, so if things look gross...sorry :see_no_evil: 
