### PR TITLE
Fix problem when destroying a non-paranoid has_one association

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -144,7 +144,12 @@ module Paranoia
       if association_data.nil? && association.macro.to_s == "has_one"
         association_class_name = association.options[:class_name].present? ? association.options[:class_name] : association.name.to_s.camelize
         association_foreign_key = association.options[:foreign_key].present? ? association.options[:foreign_key] : "#{self.class.name.to_s.underscore}_id"
-        Object.const_get(association_class_name).only_deleted.where(association_foreign_key, self.id).first.try(:restore, recursive: true)
+
+        association_class = Object.const_get(association_class_name)
+
+        if association_class.respond_to?(:only_deleted)
+          association_class.only_deleted.where(association_foreign_key, self.id).first.try(:restore, recursive: true)
+        end
       end
     end
 
@@ -157,6 +162,7 @@ class ActiveRecord::Base
     raise "primary key required for "+self.name unless self.primary_key
     alias :destroy! :destroy
     alias :delete! :delete
+
     def really_destroy!
       dependent_reflections = self.class.reflections.select do |name, reflection|
         reflection.options[:dependent] == :destroy
@@ -174,7 +180,11 @@ class ActiveRecord::Base
           end
         end
       end
-      touch_paranoia_column if ActiveRecord::VERSION::STRING >= "4.1"
+
+      if ActiveRecord::VERSION::STRING >= "4.1" && respond_to?(:touch_paranoia_column, true)
+        touch_paranoia_column
+      end
+
       destroy!
     end
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -348,9 +348,15 @@ class ParanoiaTest < test_framework
 
   def test_real_destroy_dependent_destroy
     parent = ParentModel.create
-    child = parent.very_related_models.create
+    child1 = parent.very_related_models.create
+    child2 = parent.non_paranoid_models.create
+    child3 = parent.create_non_paranoid_model
+
     parent.really_destroy!
-    refute RelatedModel.unscoped.exists?(child.id)
+
+    refute RelatedModel.unscoped.exists?(child1.id)
+    refute NonParanoidModel.unscoped.exists?(child2.id)
+    refute NonParanoidModel.unscoped.exists?(child3.id)
   end
 
   def test_real_destroy_dependent_destroy_after_normal_destroy
@@ -532,22 +538,22 @@ class ParanoiaTest < test_framework
 
     # Does it raise NoMethodException on restore of nil
     hasOne.restore(:recursive => true)
-    
+
     assert hasOne.reload.deleted_at.nil?
   end
-  
+
   # covers #131
   def test_has_one_really_destroy_with_nil
     model = ParanoidModelWithHasOne.create
     model.really_destroy!
-    
+
     refute ParanoidModelWithBelong.unscoped.exists?(model.id)
   end
-  
+
   def test_has_one_really_destroy_with_record
     model = ParanoidModelWithHasOne.create { |record| record.build_paranoid_model_with_belong }
     model.really_destroy!
-    
+
     refute ParanoidModelWithBelong.unscoped.exists?(model.id)
   end
 
@@ -678,6 +684,7 @@ class ParentModel < ActiveRecord::Base
   has_many :related_models
   has_many :very_related_models, :class_name => 'RelatedModel', dependent: :destroy
   has_many :non_paranoid_models, dependent: :destroy
+  has_one :non_paranoid_model, dependent: :destroy
   has_many :asplode_models, dependent: :destroy
 end
 


### PR DESCRIPTION
Given these models:

``` ruby
class User < ActiveRecord::Base
  acts_as_paranoid
  has_one :preference, dependent: :destroy
end

class Preference < ActiveRecord::Base
  belongs_to :user
end
```

It will raise error when performing `really_destroy!` for a `User` record.

``` ruby
user.really_destroy!
#=> NameError: undefined local variable or method `touch_paranoia_column' for #<Preference:0x007fd>
```
