### PR TITLE
Add paranoia_scope as named version of default_scope

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -183,7 +183,10 @@ class ActiveRecord::Base
 
     self.paranoia_column = (options[:column] || :deleted_at).to_s
     self.paranoia_sentinel_value = options.fetch(:sentinel_value) { Paranoia.default_sentinel_value }
-    default_scope { where(table_name => { paranoia_column => paranoia_sentinel_value }) }
+    def self.paranoia_scope
+      where(table_name => { paranoia_column => paranoia_sentinel_value })
+    end
+    default_scope { paranoia_scope }
 
     before_restore {
       self.class.notify_observers(:before_restore, self) if self.class.respond_to?(:notify_observers)


### PR DESCRIPTION
In the case when you have 2 or more default scopes by 2 or more gems and you unscope the query, but you want to use default_scope of this gem. It is very comfortable if the gem provides a named scope out of box.
