### PR TITLE
Fix restore with polymorphic has_one relationships

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -143,8 +143,16 @@ module Paranoia
 
       if association_data.nil? && association.macro.to_s == "has_one"
         association_class_name = association.options[:class_name].present? ? association.options[:class_name] : association.name.to_s.camelize
-        association_foreign_key = association.options[:foreign_key].present? ? association.options[:foreign_key] : "#{self.class.name.to_s.underscore}_id"
-        Object.const_get(association_class_name).only_deleted.where(association_foreign_key => self.id).first.try(:restore, recursive: true)
+        association_foreign_key = association.foreign_key.present? ? association.foreign_key : "#{self.class.name.to_s.underscore}_id"
+
+        if association.type
+          association_polymorphic_type = association.type
+          association_find_conditions = { association_polymorphic_type => self.class.name.to_s, association_foreign_key => self.id }
+        else
+          association_find_conditions = { association_foreign_key => self.id }
+        end
+
+        Object.const_get(association_class_name).only_deleted.where(association_find_conditions).first.try(:restore, recursive: true)
       end
     end
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -32,6 +32,7 @@ def setup!
   ActiveRecord::Base.connection.execute 'CREATE TABLE custom_column_models (id INTEGER NOT NULL PRIMARY KEY, destroyed_at DATETIME)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE custom_sentinel_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME NOT NULL)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE non_paranoid_models (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER)'
+  ActiveRecord::Base.connection.execute 'CREATE TABLE polymorphic_models (id INTEGER NOT NULL PRIMARY KEY, parent_id INTEGER, parent_type STRING, deleted_at DATETIME)'
 end
 
 class WithDifferentConnection < ActiveRecord::Base
@@ -654,6 +655,19 @@ class ParanoiaTest < test_framework
     setup!
   end
 
+  def test_restore_recursive_on_polymorphic_has_one_association
+    parent = ParentModel.create
+    polymorphic = PolymorphicModel.create(parent: parent)
+
+    parent.destroy
+
+    assert_equal 0, polymorphic.class.count
+
+    parent.restore(recursive: true)
+
+    assert_equal 1, polymorphic.class.count
+  end
+
   private
   def get_featureful_model
     FeaturefulModel.new(:name => "not empty")
@@ -706,6 +720,7 @@ class ParentModel < ActiveRecord::Base
   has_many :very_related_models, :class_name => 'RelatedModel', dependent: :destroy
   has_many :non_paranoid_models, dependent: :destroy
   has_many :asplode_models, dependent: :destroy
+  has_one :polymorphic_model, as: :parent, dependent: :destroy
 end
 
 class RelatedModel < ActiveRecord::Base
@@ -794,4 +809,9 @@ class AsplodeModel < ActiveRecord::Base
 end
 
 class NoConnectionModel < ActiveRecord::Base
+end
+
+class PolymorphicModel < ActiveRecord::Base
+  acts_as_paranoid
+  belongs_to :parent, polymorphic: true
 end


### PR DESCRIPTION
Restoring polymorphic `has_one` relationships errored because paranoia was
not correctly looking up the foreign_key.

Output from failing test -

```
ActiveRecord::StatementInvalid: SQLite3::SQLException: no such column: parent_model_id: SELECT  "polymorphic_models".* FROM "polymorphic_models" WHERE ("polymorphic_models"."deleted_at" IS NOT NULL) AND (parent_model_id)  ORDER BY "polymorphic_models"."id" ASC LIMIT 1
```

The test sets up a `PolymorphicModel`, which `has_many :parents`. The
`ParentModel` then has a `has_one` relationship with `PolymorphicModel`. When
restoring, the foreign key is set as - `self.class.name.to_s.underscore_id`
which will be `parent_model_id`, instead of the correct `:as` option.

To fix:

If the association object is a `has_one` relationship with an `:as` option,
it will have a `type` attribute (see
https://github.com/rails/docrails/blob/master/activerecord/lib/active_record/reflection.rb#L280).

If this `type` attributes is present, it will be the type column on the
polymorphic model. The foreign key can be found as an attribute on
the association object.

This should fix #174. Solution is based off of @hamidumi 's suggestions in #174.
