### PR TITLE
Add a simple Testing with Rspec section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Paranoia.default_sentinel_value = DateTime.new(0)
 
 ## Testing with Rspec
 
-You can use shared examples to help test that models are including `acts_as_paranoid` properly. For example, the following shared examples can be created in `spec/support/shared_examples/paranoid_examples.rb`:
+You can use shared examples to help test that models are including `acts_as_paranoid` properly. For example, the following shared examples can be created in `spec/support/shared_examples/paranoia_examples.rb`:
 
 ```ruby
 shared_examples_for 'a Paranoid model' do

--- a/README.md
+++ b/README.md
@@ -203,6 +203,34 @@ or globally in a rails initializer, e.g. `config/initializer/paranoia.rb`
 Paranoia.default_sentinel_value = DateTime.new(0)
 ```
 
+## Testing with Rspec
+
+You can use shared examples to help test that models are including `acts_as_paranoid` properly. For example, the following shared examples can be created in `spec/support/shared_examples/paranoid_examples.rb`:
+
+```ruby
+shared_examples_for 'a Paranoid model' do
+
+  it { should have_db_column(:deleted_at) } 
+
+  it { should have_db_index(:deleted_at) }
+
+  it 'adds a deleted_at where clause' do
+    described_class.scoped.where_sql.should include("deleted_at IS NULL")
+  end
+
+  it 'skips adding the deleted_at where clause when unscoped' do
+    described_class.unscoped.where_sql.to_s.should_not include("deleted_at")  # to_s to handle nil.
+  end
+
+end
+```
+
+And then all you need to do is include this in the specs for the model that should be acting as paranoid, like so:
+
+```ruby
+it_behaves_like 'a Paranoid model'
+```
+
 ## License
 
 This gem is released under the MIT license.


### PR DESCRIPTION
A simple shared examples for Rspec that helps people easily add tests to ensure that their models are properly including the `acts_as_paranoid` library and the model's table is properly setup with a `deleted_at` column that is indexed.

_I know you're huge on documentation and your docs for Paranoia are some of the cleanest and understandable I've seen. So, I wanted to include this to help others easily test their use of Paranoia with Rails and Rspec. Also, this might only work for SQL-based databases because it calls `where_sql` and is syntax dependent, but I think it's useful none-the-less._

_Cheers._
