### PR TITLE
Fix matcher compatibility with RSpec 2

### DIFF
--- a/lib/paranoia/rspec.rb
+++ b/lib/paranoia/rspec.rb
@@ -4,10 +4,20 @@ require 'rspec/expectations'
 RSpec::Matchers.define :act_as_paranoid do
   match { |subject| subject.class.ancestors.include?(Paranoia) }
 
-  failure_message { "expected #{subject.class} to use `acts_as_paranoid`" }
-  failure_message_when_negated { "expected #{subject.class} not to use `acts_as_paranoid`" }
+  failure_message_proc = lambda do
+    "expected #{subject.class} to use `acts_as_paranoid`"
+  end
 
-  # RSpec 2 compatibility:
-  alias_method :failure_message_for_should, :failure_message
-  alias_method :failure_message_for_should_not, :failure_message_when_negated
+  failure_message_when_negated_proc = lambda do
+    "expected #{subject.class} not to use `acts_as_paranoid`"
+  end
+
+  if respond_to?(:failure_message_when_negated)
+    failure_message(&failure_message_proc)
+    failure_message_when_negated(&failure_message_when_negated_proc)
+  else
+    # RSpec 2 compatibility:
+    failure_message_for_should(&failure_message_proc)
+    failure_message_for_should_not(&failure_message_when_negated_proc)
+  end
 end


### PR DESCRIPTION
I messed up with #156. I was thinking of the other RSpec matcher syntax where you define `failure_message_when_negated` as a method, rather than use it as a DSL call...

This way of retaining compatibility with both RSpec 2 & 3 is taken straight from the [corresponding file in the `pundit` gem](https://github.com/elabs/pundit/blob/v0.3.0/lib/pundit/rspec.rb).
