### PR TITLE
Trace feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,56 @@ If you want callbacks to trigger before a restore:
 before_restore :callback_name_goes_here
 ```
 
+#### Tracking
+
+If you want to track who deleted the record, your migration should look like this:
+``` shell
+bundle exec rails g migration add_deleted_at_and_deleted_by_to_clients deleted_at:datetime:index deleted_by:integer:index
+```
+
+migration file:
+
+``` ruby
+class AddDeletedAtAndDeletedByToClients < ActiveRecord::Migration
+  def change
+    add_column :users, :deleted_at, :datetime
+    add_index :users, :deleted_at
+    add_column :users, :deleted_by, :integer
+    add_index :users, :deleted_by
+  end
+end
+
+in your model:
+
+``` ruby
+class Client < ActiveRecord::Base
+  acts_as_paranoid trackable: true
+
+  ...
+end
+```
+
+Now, you can indicate who deleted the record, passing `deleted_by_id` option into `destroy` method, for example:
+
+``` ruby
+def destroy
+  @client = Client.find(params[:id])
+  @client.destroy(deleted_by_id: current_user.id)
+
+  ...
+end
+```
+
+If you want to use custom column name for destroyer tracking, you can pass it as an option:
+
+``` ruby
+class Client < ActiveRecord::Base
+  acts_as_paranoid trackable: true, trackable_column: :destroyed_by_id
+
+  ...
+end
+```
+
 For more information, please look at the tests.
 
 ## Acts As Paranoid Migration

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ class AddDeletedAtAndDeletedByToClients < ActiveRecord::Migration
     add_index :users, :deleted_by
   end
 end
+```
 
 in your model:
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -33,6 +33,8 @@ def setup!
   ActiveRecord::Base.connection.execute 'CREATE TABLE custom_sentinel_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME NOT NULL)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE non_paranoid_models (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER)'
   ActiveRecord::Base.connection.execute 'CREATE TABLE polymorphic_models (id INTEGER NOT NULL PRIMARY KEY, parent_id INTEGER, parent_type STRING, deleted_at DATETIME)'
+  ActiveRecord::Base.connection.execute 'CREATE TABLE trackable_models (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME, deleted_by_id INTEGER)'
+  ActiveRecord::Base.connection.execute 'CREATE TABLE trackable_model_with_destroyed_by_ids (id INTEGER NOT NULL PRIMARY KEY, deleted_at DATETIME, destroyed_by_id INTEGER)'
 end
 
 class WithDifferentConnection < ActiveRecord::Base
@@ -758,6 +760,51 @@ class ParanoiaTest < test_framework
     assert_equal 0, polymorphic.class.count
   end
 
+  def test_trackable_model
+    deleted_by_id = 5
+    record = TrackableModel.create!
+    record.destroy(deleted_by_id: deleted_by_id)
+    record.reload
+    assert_equal deleted_by_id, record.deleted_by_id
+    assert record.deleted?
+  end
+
+  def test_trackable_model_with_custom_trackable_column_name
+    deleted_by_id = 5
+    record = TrackableModelWithDestroyedById.create!
+    record.destroy(deleted_by_id: deleted_by_id)
+    record.reload
+    assert_equal deleted_by_id, record.destroyed_by_id
+    assert record.deleted?
+  end
+
+  def test_trackable_model_restore
+    deleted_by_id = 5
+    record = TrackableModel.create!
+    record.destroy(deleted_by_id: deleted_by_id)
+    record.restore!
+    record.reload
+    assert !record.deleted?
+    assert_nil record.deleted_by_id
+  end
+
+  def test_deleted_by_scope
+    deleted_by_id = 5
+    record = TrackableModel.create!
+    record.destroy(deleted_by_id: deleted_by_id)
+    relation = TrackableModel.deleted_by(deleted_by_id)
+    assert_equal 1, relation.count
+    assert_equal record, relation.first
+  end
+
+  def test_trackable_model_without_providing_value
+    record = TrackableModel.create!
+    record.destroy
+    record.reload
+    assert record.deleted?
+    assert_nil record.deleted_by_id
+  end
+
   private
   def get_featureful_model
     FeaturefulModel.new(:name => "not empty")
@@ -929,4 +976,12 @@ end
 class PolymorphicModel < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :parent, polymorphic: true
+end
+
+class TrackableModel < ActiveRecord::Base
+  acts_as_paranoid trackable: true
+end
+
+class TrackableModelWithDestroyedById < ActiveRecord::Base
+  acts_as_paranoid trackable: true, trackable_column: :destroyed_by_id
 end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -791,6 +791,8 @@ class ParanoiaTest < test_framework
   def test_deleted_by_scope
     deleted_by_id = 5
     record = TrackableModel.create!
+    # record 2:
+    TrackableModel.create!
     record.destroy(deleted_by_id: deleted_by_id)
     relation = TrackableModel.deleted_by(deleted_by_id)
     assert_equal 1, relation.count


### PR DESCRIPTION
This feature allows to keep track of who deleted specific record. By default, it's enough to add `deleted_by_id` column to appropriate table, use `acts_as_paranoid trackable: true` in model and pass `deleted_by_id` as an option to `destroy` method. 
