### PR TITLE
fix ActiveRecord::StatementInvalid: PG::UndefinedTable (https://github.com/rails/rails/issues/12770)

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -182,7 +182,7 @@ class ActiveRecord::Base
     self.paranoia_column = (options[:column] || :deleted_at).to_s
     self.paranoia_sentinel_value = options.fetch(:sentinel_value) { Paranoia.default_sentinel_value }
     def self.paranoia_scope
-      where(table_name => { paranoia_column => paranoia_sentinel_value })
+      where("#{paranoia_column}" => paranoia_sentinel_value)
     end
     default_scope { paranoia_scope }
 


### PR DESCRIPTION
fix ActiveRecord::StatementInvalid: PG::UndefinedTable: invalid reference to FROM-clause ..., use table name alias (https://github.com/rails/rails/issues/12770)
