### PR TITLE
Remove table_name from where methods

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -29,7 +29,7 @@ module Paranoia
     end
 
     def only_deleted
-      with_deleted.where.not(table_name => { paranoia_column => paranoia_sentinel_value} )
+      with_deleted.where.not(paranoia_column => paranoia_sentinel_value)
     end
     alias :deleted :only_deleted
 
@@ -182,7 +182,7 @@ class ActiveRecord::Base
     self.paranoia_column = (options[:column] || :deleted_at).to_s
     self.paranoia_sentinel_value = options.fetch(:sentinel_value) { Paranoia.default_sentinel_value }
     def self.paranoia_scope
-      where(table_name => { paranoia_column => paranoia_sentinel_value })
+      where(paranoia_column => paranoia_sentinel_value)
     end
     default_scope { paranoia_scope }
 


### PR DESCRIPTION
There is no need to specify `table_name` because Rails does it automatically.

More over, explicit specifying `table_name` failed for me in such case.

``` ruby
class FirstModel
  has_many :second_models
  has_many :third_models, through: :second_models
end

class SecondModel
  belongs_to :first_model
  has_many :third_models
end

class ThirdModel
  belongs_to :first_model
end

FirstModel.first.third_models.joins(:second_models).to_sql
```

``` sql
SELECT `third_models`.*
    FROM `third_models`
        INNER JOIN `second_models` `secod_models_third_models`
            ON `secod_models_third_models`.`id` = `third_models`.`second_model_id`
                AND `second_models`.`deleted_at` IS NULL
                AND `secod_models_third_models`.`id` = 1
        INNER JOIN `second_models` ON `third_models`.`second_model_id` = `second_models`.`id`
    WHERE `third_models`.`deleted_at` IS NULL
        AND `second_models`.`deleted_at` IS NULL
        AND `second_models`.`id` = 1
        AND `second_models`.`first_model_id` = 1
```

```
Unknown column 'second_models.deleted_at' in 'on clause'
```

I know that `joins(:second_models)` is a bit redundant but it is done automatically by universal scoping in my code. Still, it should not fail in any case.

There is another issue - double joining - but it is another problem.
