### PR TITLE
Update README about rails3 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ gem "paranoia", "~> 2.0"
 Of course you can install this from GitHub as well:
 
 ``` ruby
-gem "paranoia", :github => "radar/paranoia", :branch => "master"
+gem "paranoia", :github => "radar/paranoia", :branch => "rails3"
 # or
 gem "paranoia", :github => "radar/paranoia", :branch => "rails4"
 ```


### PR DESCRIPTION
Repository do not contain `master` branch any more.
