### PR TITLE
check paranoia_column existence

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -201,7 +201,7 @@ class ActiveRecord::Base
     def self.paranoia_scope
       where(paranoia_column => paranoia_sentinel_value)
     end
-    default_scope { paranoia_scope }
+    default_scope { paranoia_scope if columns_hash.has_key? paranoia_column }
 
     before_restore {
       self.class.notify_observers(:before_restore, self) if self.class.respond_to?(:notify_observers)

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -34,7 +34,8 @@ def setup!
     'custom_column_models' => 'destroyed_at DATETIME',
     'custom_sentinel_models' => 'deleted_at DATETIME NOT NULL',
     'non_paranoid_models' => 'parent_model_id INTEGER',
-    'polymorphic_models' => 'parent_id INTEGER, parent_type STRING, deleted_at DATETIME'
+    'polymorphic_models' => 'parent_id INTEGER, parent_type STRING, deleted_at DATETIME',
+    'paranoid_model_without_deleted_columns' => 'foo INTEGER'
   }.each do |table_name, columns_as_sql_string|
     ActiveRecord::Base.connection.execute "CREATE TABLE #{table_name} (id INTEGER NOT NULL PRIMARY KEY, #{columns_as_sql_string})"
   end
@@ -430,6 +431,10 @@ class ParanoiaTest < test_framework
     refute RelatedModel.unscoped.exists?(child1.id)
     refute NonParanoidModel.unscoped.exists?(child2.id)
     refute NonParanoidModel.unscoped.exists?(child3.id)
+  end
+
+  def test_paranoid_model_without_deleted_column
+    assert_equal true, ParanoidModelWithoutDeletedColumn.first.nil?
   end
 
   def test_real_destroy_dependent_destroy_after_normal_destroy
@@ -919,6 +924,10 @@ class CustomSentinelModel < ActiveRecord::Base
 end
 
 class NonParanoidModel < ActiveRecord::Base
+end
+
+class ParanoidModelWithoutDeletedColumn < ActiveRecord::Base
+  acts_as_paranoid
 end
 
 class ParanoidModelWithObservers < ParanoidModel


### PR DESCRIPTION
We were using Rails models on database migrations, so if we run `rake db:migrate` from scratch will fail as 

> rake aborted!
> StandardError: An error has occurred, this and all later migrations canceled
> 
> SQLite3::SQLException: no such column: posts.deleted_at: SELECT "posts".\* FROM "posts" WHERE "posts"."deleted_at" IS NULL/Users/juanfperez/.rvm/gems/ruby-head/gems/sqlite3-1.3.10/lib/sqlite3/database.rb:91:in `initialize'

This can be solved checking for the column existence.

_Of course, it can be solved if we made a trick on the migration file. That way we can avoid the call to `act_as_paranoid`_

``` ruby
class MigrateData < ActiveRecord::Migration
  class Post < ActiveRecord::Base;end

  def change
    Post.all.each do |post|
      post.update_attributes title: 'untitled'
    end
  end
end
```
