### PR TITLE
Failing test case for "after_commit" on destroy

### DIFF
--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -111,6 +111,14 @@ class ParanoiaTest < test_framework
     assert model.instance_variable_get(:@after_commit_callback_called)
   end
 
+  def test_destroy_behavior_for_conditional_models_callbacks
+    model = ConditionalCallbackModel.new
+    model.save
+    model.remove_called_variables     # clear called callback flags
+    model.destroy
+
+    assert model.instance_variable_get(:@after_commit_callback_called)
+  end
 
   def test_delete_behavior_for_plain_models_callbacks
     model = CallbackModel.new
@@ -852,6 +860,18 @@ class CallbackModel < ActiveRecord::Base
   after_commit   {|model| model.instance_variable_set :@after_commit_callback_called, true }
 
   validate       {|model| model.instance_variable_set :@validate_called, true }
+
+  def remove_called_variables
+    instance_variables.each {|name| (name.to_s.end_with?('_called')) ? remove_instance_variable(name) : nil}
+  end
+end
+
+class ConditionalCallbackModel < ActiveRecord::Base
+  self.table_name = 'callback_models'
+
+  acts_as_paranoid
+
+  after_commit   -> { instance_variable_set :@after_commit_callback_called, true }, on: :destroy
 
   def remove_called_variables
     instance_variables.each {|name| (name.to_s.end_with?('_called')) ? remove_instance_variable(name) : nil}


### PR DESCRIPTION
We're just upgrading an application which uses the paranoia gem (rails4 branch) to Rails 4.2.1 - We've several models which are using conditional `after_commit` hooks, e.g.: 

``` ruby
after_commit   -> { do_stuff }, on: :destroy
```

This breaks for `destroy`, since it's [depending on](https://github.com/rails/rails/blob/c539cc006179c98d418c6914ce567f657b6f1966/activerecord/lib/active_record/transactions.rb#L433-L444) `destroy?` which changed its behaviour with #177. 

Our workaround will probably look somehow like this:

``` ruby

class ActiveRecord::Base
  private

  # Determine if a transaction included an action for :create, :update, or :destroy. Used in filtering callbacks.
  def transaction_include_any_action?(actions) #:nodoc:
    actions.any? do |action|
      case action
      when :create
        transaction_record_state(:new_record)
      when :destroy
        destroyed? || (respond_to?(:paranoia_destroyed?) && paranoia_destroyed?)
      when :update
        !(transaction_record_state(:new_record) || destroyed? || (respond_to?(:paranoia_destroyed?) && paranoia_destroyed?))
      end
    end
  end
end
```

However, we're wondering if anyone has (or could think of) a nicer solution for this?
