### PR TITLE
Paranoia.without!

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -2,6 +2,7 @@ require 'active_record' unless defined? ActiveRecord
 
 module Paranoia
   @@default_sentinel_value = nil
+  @@disabled = false
 
   # Change default_sentinel_value in a rails initilizer
   def self.default_sentinel_value=(val)
@@ -10,6 +11,16 @@ module Paranoia
 
   def self.default_sentinel_value
     @@default_sentinel_value
+  end
+  
+  def self.disabled(&block)
+    @@disabled = true
+    block.call
+    @@disabled = false
+  end
+  
+  def self.disabled?
+    @@disabled == true
   end
 
   def self.included(klazz)
@@ -167,6 +178,8 @@ end
 
 class ActiveRecord::Base
   def self.acts_as_paranoid(options={})
+    return if Paranoia.disabled?
+    
     alias :really_destroyed? :destroyed?
     alias :really_delete :delete
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -14,9 +14,13 @@ module Paranoia
   end
   
   def self.disabled(&block)
-    @@disabled = true
+    disabled!
     block.call
     @@disabled = false
+  end
+  
+  def self.disabled!
+    @@disabled = true
   end
   
   def self.disabled?

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -182,8 +182,6 @@ end
 
 class ActiveRecord::Base
   def self.acts_as_paranoid(options={})
-    return if Paranoia.without?
-    
     alias :really_destroyed? :destroyed?
     alias :really_delete :delete
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -218,7 +218,7 @@ class ActiveRecord::Base
     def self.paranoia_scope
       where(paranoia_column => paranoia_sentinel_value)
     end
-    default_scope { paranoia_scope }
+    default_scope { paranoia_scope } unless Paranoia.disabled?
 
     before_restore {
       self.class.notify_observers(:before_restore, self) if self.class.respond_to?(:notify_observers)


### PR DESCRIPTION
It is sometimes needed to run some code without Paranoia's default_scope, so here is the patch for it :-) 

Eg.

``` ruby
Paranoia.without!
User.staff.find_each do |user|
  # do some work here
end
```

or even better:

``` ruby
Paranoia.without do
  User.staff.find_each do |user|
    # do some work here
  end
end
```
