### PR TITLE
Fix association class name for namespaced has one model lookups

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -144,7 +144,7 @@ module Paranoia
       end
 
       if association_data.nil? && association.macro.to_s == "has_one"
-        association_class_name = association.class_name
+        association_class_name = association.klass.name
         association_foreign_key = association.foreign_key
 
         if association.type


### PR DESCRIPTION
Use association.klass.name instead of association.class_name to get the
namespaced class name and therefore prevent:

`Object.get_const(association_class_name)`

from raising "uninitialized constant ParanoidHasOne"
in the following situation:

``` ruby
module Something
  def self.table_name_prefix
    "something_"
  end

  class ParanoidHasOne < ActiveRecord::Base
    acts_as_paranoid
    has_one :paranoid_belongs_to, dependent: :destroy
  end

  class ParanoidBelongsTo < ActiveRecord::Base
    acts_as_paranoid
    belongs_to :paranoid_has_one
  end
end

hasOne = Namespaced::ParanoidHasOne.create
hasOne.destroy
hasOne.restore(:recursive => true) # previously would explode
```
