### PR TITLE
Fix uniqueness validator for non-paranoid associations

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -250,7 +250,11 @@ module ActiveRecord
       protected
       def build_relation_with_paranoia(klass, table, attribute, value)
         relation = build_relation_without_paranoia(klass, table, attribute, value)
-        relation.and(klass.arel_table[klass.paranoia_column].eq(nil))
+        if klass.respond_to?(:paranoia_column)
+          relation.and(klass.arel_table[klass.paranoia_column].eq(nil))
+        else
+          relation
+        end
       end
       alias_method_chain :build_relation, :paranoia
     end


### PR DESCRIPTION
One of my paranoid models has a relation to a non-paranoid sub-model. With the current version of the `UniquenessValidator` enhancement, this caused paranoia to fail.
I added a test for this constellation and implemented the corresponding fix.
