### PR TITLE
Fix uniqueness validator for non-paranoid models.

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -181,7 +181,11 @@ module ActiveRecord
       protected
       def build_relation_with_paranoia(klass, table, attribute, value)
         relation = build_relation_without_paranoia(klass, table, attribute, value)
-        relation.and(klass.arel_table[klass.paranoia_column].eq(nil))
+        if klass.respond_to?(:paranoia_column)
+          relation.and(klass.arel_table[klass.paranoia_column].eq(nil))
+        else
+          relation
+        end
       end
       alias_method_chain :build_relation, :paranoia
     end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -21,6 +21,7 @@ ActiveRecord::Base.connection.execute 'CREATE TABLE employees (id INTEGER NOT NU
 ActiveRecord::Base.connection.execute 'CREATE TABLE jobs (id INTEGER NOT NULL PRIMARY KEY, employer_id INTEGER NOT NULL, employee_id INTEGER NOT NULL, deleted_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE custom_column_models (id INTEGER NOT NULL PRIMARY KEY, destroyed_at DATETIME)'
 ActiveRecord::Base.connection.execute 'CREATE TABLE non_paranoid_models (id INTEGER NOT NULL PRIMARY KEY, parent_model_id INTEGER)'
+ActiveRecord::Base.connection.execute 'CREATE TABLE non_paranoid_unique_models (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(10))'
 
 class ParanoiaTest < Test::Unit::TestCase
   def test_plain_model_class_is_not_paranoid
@@ -448,6 +449,12 @@ class ParanoiaTest < Test::Unit::TestCase
     refute b.valid?
   end
 
+  def test_validates_uniqueness_still_works_on_non_paranoid_models
+    a = NonParanoidUniqueModel.create!(name: "A")
+    b = NonParanoidUniqueModel.new(name: "A")
+    refute b.valid?
+  end
+
   private
   def get_featureful_model
     FeaturefulModel.new(:name => 'not empty')
@@ -533,6 +540,10 @@ class CustomColumnModel < ActiveRecord::Base
 end
 
 class NonParanoidModel < ActiveRecord::Base
+end
+
+class NonParanoidUniqueModel < ActiveRecord::Base
+  validates :name, :uniqueness => true
 end
 
 class ParanoidModelWithObservers < ParanoidModel


### PR DESCRIPTION
As I mentioned on #250, simply attempting to create a non paranoid model with an uniqueness validation fails since it attempts to filter out records with paranoid column != nil from the relation. This is the very same fix in 3b6ff6ec but for this rails3 branch which is what I'm depending on. 
