### PR TITLE
Update paranoia.gemspec

### DIFF
--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "paranoia"
 
-  s.add_dependency "activerecord", "~> 4.0"
+  s.add_dependency "activerecord", ">= 4.0"
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake"


### PR DESCRIPTION
Update activerecord dependency to work with later activerecord version: for use paranoia with rails 5, that depends on activerecord ~> 5.0
