### PR TITLE
Remove unused method leaking into ActiveRecord::Relation

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -235,17 +235,6 @@ class ActiveRecord::Base
     }
   end
 
-  # Please do not use this method in production.
-  # Pretty please.
-  def self.I_AM_THE_DESTROYER!
-    # TODO: actually implement spelling error fixes
-    puts %Q{
-      Sharon: "There should be a method called I_AM_THE_DESTROYER!"
-      Ryan:   "What should this method do?"
-      Sharon: "It should fix all the spelling errors on the page!"
-}
-  end
-
   def self.paranoid? ; false ; end
   def paranoid? ; self.class.paranoid? ; end
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -757,17 +757,6 @@ class ParanoiaTest < test_framework
     refute b.valid?
   end
 
-  def test_i_am_the_destroyer
-    expected = %Q{
-      Sharon: "There should be a method called I_AM_THE_DESTROYER!"
-      Ryan:   "What should this method do?"
-      Sharon: "It should fix all the spelling errors on the page!"
-}
-    assert_output expected do
-      ParanoidModel.I_AM_THE_DESTROYER!
-    end
-  end
-
   def test_destroy_fails_if_callback_raises_exception
     parent = AsplodeModel.create
 


### PR DESCRIPTION
Hi guys, I thought I might chip in here

I'm all for [easter eggs](https://github.com/mperham/sidekiq/blob/f37562f812ebb1c1136553d4f38d6863c3cba835/lib/sidekiq.rb#L40-L42) in Ruby community, but this method is leaking into every single thing that touches ActiveRecord.

It would be fine if it was under its own namespace, like Sidekiq's one, but this method gets included in every single `ActiveRecord::Base`-dependent class and - by extension - into `ActiveRecord::Relation` instance:

``` ruby
# AR::Base class methods
Post.I_AM_THE_DESTROYER!
Comment.I_AM_THE_DESTROYER!
# AR::Associations::CollectionProxy
User.first.comments.I_AM_THE_DESTROYER!
# AR::Relation
User.joins(:comments).I_AM_THE_DESTROYER!
```

There's probably loads more, but these are just couple that I know of on top of my head.

Let's keep `AR::Base` clean, please?
