### PR TITLE
Not deleted scope

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -41,6 +41,10 @@ module Paranoia
       end
     end
     alias :deleted :only_deleted
+    
+    def not_deleted
+      where(paranoia_column => paranoia_sentinel_value)
+    end
 
     def restore(id_or_ids, opts = {})
       ids = Array(id_or_ids).flatten

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -175,6 +175,7 @@ class ParanoiaTest < test_framework
     p1.destroy
     p2.destroy
     assert_equal 0, parent1.paranoid_models.count
+    assert_equal 0, parent1.paranoid_models.unscoped.not_deleted.count
     assert_equal 1, parent1.paranoid_models.only_deleted.count
     assert_equal 1, parent1.paranoid_models.deleted.count
     p3 = ParanoidModel.create(:parent_model => parent1)
@@ -295,6 +296,17 @@ class ParanoiaTest < test_framework
 
     assert_equal model, ParanoidModel.only_deleted.last
     assert_equal false, ParanoidModel.only_deleted.include?(model2)
+  end
+  
+  def test_not_deleted_scope_for_paranoid_models
+    model = ParanoidModel.new
+    model.save
+    model.destroy
+    model2 = ParanoidModel.new
+    model2.save
+
+    assert_equal model2, ParanoidModel.unscoped.not_deleted.first
+    assert_equal false, ParanoidModel.unscoped.not_deleted.include?(model)
   end
 
   def test_default_scope_for_has_many_relationships


### PR DESCRIPTION
Hi Radar,

In this PR I add an additional scope `not_deleted` that mimic the default_scope provided by this gem. 

I considered it a usefult feature in the following scenario. There is a model `TestModel` with a complex `default_scope`. On a particular type of queries, when you call `TestModel.unscoped` then you get rid also of the default_scope provided by paranoia. In order to provide a descriptive scope, now it is possible to call `TestModel.unscoped.not_deleted`

I hope you like it :)
