### PR TITLE
Ensure delete_all and destroy_all are paranoid

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -249,6 +249,10 @@ class ActiveRecord::Base
   def self.paranoid? ; false ; end
   def paranoid? ; self.class.paranoid? ; end
 
+  def self.delete_all(conditions=nil)
+    super and return unless paranoid?
+    where(conditions).update_all(self.new.send :paranoia_destroy_attributes)
+  end
   private
 
   def paranoia_column

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -879,6 +879,36 @@ class ParanoiaTest < test_framework
     related.valid?
   end
 
+  def test_delete_all
+    model = ParanoidModel
+    count = 3
+    models = count.times.map { model.new }
+    assert_equal 0, model.count
+    models.each(&:save!)
+
+    assert_equal count, model.count
+    model.delete_all
+
+    assert_equal 0, model.count
+    assert_equal count, model.with_deleted.count
+
+    assert model.with_deleted.all?(&:deleted?)
+  end
+
+  def test_delete_all_for_non_paranoid_model
+    model = PlainModel
+    count = 3
+    models = count.times.map { model.new }
+    assert_equal 0, model.count
+    models.each(&:save!)
+
+    assert_equal count, model.count
+    model.delete_all
+
+    assert_equal 0, model.count
+    assert_equal 0, model.unscoped.count
+  end
+
   # TODO: find a fix for Rails 4.1
   if ActiveRecord::VERSION::STRING !~ /\A4\.1/
     def test_counter_cache_column_update_on_really_destroy

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -909,6 +909,34 @@ class ParanoiaTest < test_framework
     assert_equal 0, model.unscoped.count
   end
 
+  def test_destroy_all
+    model = ParanoidModel
+    count = 3
+    models = count.times.map { model.new }
+    assert_equal 0, model.count
+    models.each(&:save!)
+
+    assert_equal count, model.count
+    model.destroy_all
+
+    assert_equal 0, model.count
+    assert_equal 3, model.unscoped.count
+  end
+
+  def test_destroy_all_for_non_paranoid_model
+    model = PlainModel
+    count = 3
+    models = count.times.map { model.new }
+    assert_equal 0, model.count
+    models.each(&:save!)
+
+    assert_equal count, model.count
+    model.destroy_all
+
+    assert_equal 0, model.count
+    assert_equal 0, model.unscoped.count
+  end
+
   # TODO: find a fix for Rails 4.1
   if ActiveRecord::VERSION::STRING !~ /\A4\.1/
     def test_counter_cache_column_update_on_really_destroy


### PR DESCRIPTION
- Previously: delete_all calls would simply erase the models form the database 
- Previously: there weren't any specs for destroy_all
