### PR TITLE
Reverts breaking behaviour introduced in v2.1.4

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -254,17 +254,3 @@ class ActiveRecord::Base
 end
 
 require 'paranoia/rspec' if defined? RSpec
-
-module ActiveRecord
-  module Validations
-    class UniquenessValidator < ActiveModel::EachValidator
-      protected
-      def build_relation_with_paranoia(klass, table, attribute, value)
-        relation = build_relation_without_paranoia(klass, table, attribute, value)
-        return relation unless klass.respond_to?(:paranoia_column)
-        relation.and(klass.arel_table[klass.paranoia_column].eq(klass.paranoia_sentinel_value))
-      end
-      alias_method_chain :build_relation, :paranoia
-    end
-  end
-end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -222,11 +222,11 @@ class ParanoiaTest < test_framework
     assert_equal 1, model.class.deleted.count
   end
 
-  def test_active_column_model_with_uniqueness_validation_only_checks_non_deleted_records
+  def test_active_column_model_with_uniqueness_validation_checks_all_records
     a = ActiveColumnModelWithUniquenessValidation.create!(name: "A")
     a.destroy
     b = ActiveColumnModelWithUniquenessValidation.new(name: "A")
-    assert b.valid?
+    refute b.valid?
   end
 
   def test_active_column_model_with_uniqueness_validation_still_works_on_non_deleted_records
@@ -744,11 +744,11 @@ class ParanoiaTest < test_framework
     # essentially, we're just ensuring that this doesn't crash
   end
 
-  def test_validates_uniqueness_only_checks_non_deleted_records
+  def test_validates_uniqueness_checks_all_records
     a = Employer.create!(name: "A")
     a.destroy
     b = Employer.new(name: "A")
-    assert b.valid?
+    refute b.valid?
   end
 
   def test_validates_uniqueness_still_works_on_non_deleted_records


### PR DESCRIPTION
Removed the patch to `ActiveRecord::Validations::UniquenessValidator` as it caused breaking changes.

See ticket #276 

Test updated to reflect old behaviour
