### PR TITLE
Adding support to cancel "restore" and "real_destroy" actions

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -55,7 +55,7 @@ module Paranoia
   module Callbacks
     def self.extended(klazz)
       [:restore, :real_destroy].each do |callback_name|
-        klazz.define_callbacks callback_name
+        klazz.define_callbacks callback_name, terminator: ->(_, result) { result == false }
 
         klazz.define_singleton_method("before_#{callback_name}") do |*args, &block|
           set_callback(callback_name, :before, *args, &block)


### PR DESCRIPTION
Currently the callbacks for `before_restore` and `before_real_destroy` can't be canceled (via returning `false`) like any other normal ActiveModel::Callback. So here I'm adding the support to cancel any of those actions (`restore` or `real_destroy`) by returning `false` in their callbacks.
