### PR TITLE
Don't try to add to null transactions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
   - 2.0.0
-  - 2.1.0
-  - 2.2.0
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
   - jruby-19mode
 
 env:

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -93,7 +93,7 @@ module Paranoia
     if persisted?
       # if a transaction exists, add the record so that after_commit
       # callbacks can be run
-      add_to_transaction
+      add_to_transaction unless self.class.connection.current_transaction.closed?
       update_columns(paranoia_destroy_attributes)
     elsif !frozen?
       assign_attributes(paranoia_destroy_attributes)

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -88,6 +88,14 @@ class ParanoiaTest < test_framework
     assert_equal to_param, model.to_param
   end
 
+  def test_paranoid_model_delete_outside_transaction
+    model = ParanoidModel.new
+    model.save!
+
+    model.delete
+    assert model.to_param
+  end
+
   def test_destroy_behavior_for_plain_models
     model = PlainModel.new
     assert_equal 0, model.class.count
@@ -762,7 +770,7 @@ class ParanoiaTest < test_framework
     parent1 = ParentModel.create
     pt1 = ParanoidModelWithTimestamp.create(:parent_model => parent1)
     ParanoidModelWithTimestamp.record_timestamps = false
-    pt1.update_columns(created_at: 20.years.ago, updated_at: 10.years.ago, deleted_at: 10.years.ago) 
+    pt1.update_columns(created_at: 20.years.ago, updated_at: 10.years.ago, deleted_at: 10.years.ago)
     ParanoidModelWithTimestamp.record_timestamps = true
     assert pt1.updated_at < 10.minutes.ago
     refute pt1.deleted_at.nil?


### PR DESCRIPTION
Fixes https://github.com/rubysherpas/paranoia/issues/274

It looks like ActiveRecord refactored the Transaction class hierarchy in
a non-backwards-compatible
way (https://github.com/rails/rails/pull/16363), which breaks
`add_to_transaction` for null transactions (I think it probably
qualifies as a bug). The workaround is to not try to use
`add_to_transaction` in null transactions.
