### PR TITLE
Use TravisCI's container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 2.0.0


### PR DESCRIPTION
This makes the startup time for tests much faster.

This also fixes an issue where bundle install would fail because the
version on travis's legacy infrastructure is too old.

See: https://github.com/bundler/bundler/issues/3558
