### PR TITLE
Call `add_to_transaction` on #restore! as well

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -108,6 +108,9 @@ module Paranoia
         # This only happened on Rails versions earlier than 4.1.
         noop_if_frozen = ActiveRecord.version < Gem::Version.new("4.1")
         if (noop_if_frozen && !@attributes.frozen?) || !noop_if_frozen
+          # if a transaction exists, add the record so that after_commit
+          # callbacks can be run
+          add_to_transaction
           write_attribute paranoia_column, paranoia_sentinel_value
           update_columns(paranoia_restore_attributes)
           touch


### PR DESCRIPTION
Under certain conditions, combining the use of paranoia and
counter_culture can result in callbacks not being run. This is
perhaps due to an interaction between after_commit_action and
user-defined after_commit callbacks, but unfortunately I have been
unable to pin this down in tests.

Note this makes restore! roughly symmetric with delete/destroy in
its existing use of add_to_transaction.
