### PR TITLE
Added without_default_scope option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ class Client < ActiveRecord::Base
 end
 ```
 
+
+If you want to skip adding the default scope
+
+``` ruby
+class Client < ActiveRecord::Base
+  acts_as_paranoid without_default_scope: true
+
+  ...
+end
+```
+
 If you want to access soft-deleted associations, override the getter method:
 
 ``` ruby

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -219,7 +219,10 @@ class ActiveRecord::Base
     def self.paranoia_scope
       where(paranoia_column => paranoia_sentinel_value)
     end
-    default_scope { paranoia_scope }
+    
+    unless options[:without_default_scope]
+      default_scope { paranoia_scope }
+    end
 
     before_restore {
       self.class.notify_observers(:before_restore, self) if self.class.respond_to?(:notify_observers)

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -40,7 +40,8 @@ def setup!
     'namespaced_paranoid_belongs_tos' => 'deleted_at DATETIME, paranoid_has_one_id INTEGER',
     'unparanoid_unique_models' => 'name VARCHAR(32), paranoid_with_unparanoids_id INTEGER',
     'active_column_models' => 'deleted_at DATETIME, active BOOLEAN',
-    'active_column_model_with_uniqueness_validations' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN'
+    'active_column_model_with_uniqueness_validations' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN',
+    'without_default_scope_models' => 'deleted_at DATETIME'
   }.each do |table_name, columns_as_sql_string|
     ActiveRecord::Base.connection.execute "CREATE TABLE #{table_name} (id INTEGER NOT NULL PRIMARY KEY, #{columns_as_sql_string})"
   end
@@ -205,10 +206,11 @@ class ParanoiaTest < test_framework
   end
 
   def test_without_default_scope_option
-    model = WithoutDefaultScopeModel.create!(name: "A", deleted_at: Time.now)
+    model = WithoutDefaultScopeModel.create
+    model.destroy
     assert_equal 1, model.class.count
     assert_equal 1, model.class.only_deleted.count
-    assert_equal 0, model.class.without_deleted.count
+    assert_equal 0, model.class.where(deleted_at: nil).count
   end
 
   def test_active_column_model

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -204,6 +204,13 @@ class ParanoiaTest < test_framework
     assert_equal nil, ParanoidModel.paranoia_sentinel_value
   end
 
+  def test_without_default_scope_option
+    model = WithoutDefaultScopeModel.create!(name: "A", deleted_at: Time.now)
+    assert_equal 1, model.class.count
+    assert_equal 1, model.class.only_deleted.count
+    assert_equal 0, model.class.without_deleted.count
+  end
+
   def test_active_column_model
     model = ActiveColumnModel.new
     assert_equal 0, model.class.count
@@ -1040,6 +1047,10 @@ end
 
 class CustomSentinelModel < ActiveRecord::Base
   acts_as_paranoid sentinel_value: DateTime.new(0)
+end
+
+class WithoutDefaultScopeModel < ActiveRecord::Base
+  acts_as_paranoid without_default_scope: true
 end
 
 class ActiveColumnModel < ActiveRecord::Base


### PR DESCRIPTION
I added an option to skip the default_scope. This makes the gem much more versatile and not susceptible to all the problems that come with default_scope.
