### PR TITLE
Add scope without_deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ end
 ```
 
 
-If you want to skip adding the default scope
+If you want to skip adding the default scope:
 
 ``` ruby
 class Client < ActiveRecord::Base
@@ -137,6 +137,12 @@ If you want to find all records, even those which are deleted:
 
 ``` ruby
 Client.with_deleted
+```
+
+If you want to exclude deleted records, when not able to use the default_scope (e.g. when using without_default_scope):
+
+``` ruby
+Client.without_deleted
 ```
 
 If you want to find only the deleted records:

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -219,7 +219,8 @@ class ActiveRecord::Base
     def self.paranoia_scope
       where(paranoia_column => paranoia_sentinel_value)
     end
-    
+    class << self; alias_method :without_deleted, :paranoia_scope end
+
     unless options[:without_default_scope]
       default_scope { paranoia_scope }
     end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -186,8 +186,10 @@ class ParanoiaTest < test_framework
     assert_equal 0, parent1.paranoid_models.count
     assert_equal 1, parent1.paranoid_models.only_deleted.count
     assert_equal 1, parent1.paranoid_models.deleted.count
+    assert_equal 0, parent1.paranoid_models.without_deleted.count
     p3 = ParanoidModel.create(:parent_model => parent1)
     assert_equal 2, parent1.paranoid_models.with_deleted.count
+    assert_equal 1, parent1.paranoid_models.without_deleted.count
     assert_equal [p1,p3], parent1.paranoid_models.with_deleted
   end
 


### PR DESCRIPTION
When using the option :without_default_scope it makes sense to have a scope to exclude paranoia-deleted records, which is essentially the paranoia_scope.
Aliased it to without_deleted as opposed to the existing with_deleted scope.
