### PR TITLE
Fixed README for rails 5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,16 @@ For Rails 3, please use version 1 of Paranoia:
 gem "paranoia", "~> 1.0"
 ```
 
-For Rails 4 or 5, please use version 2 of Paranoia:
+For Rails 4, please use version 2 of Paranoia:
 
 ``` ruby
 gem "paranoia", "~> 2.0"
+```
+
+For Rails 5, please use the "core" branch of Paranoia:
+
+``` ruby
+gem 'paranoia', github: 'rubysherpas/paranoia', branch: 'core'
 ```
 
 Of course you can install this from GitHub as well:


### PR DESCRIPTION
Instructions in README were incorrect. Attempting to use 2.0 for rails 5 leads to:

```
Resolving dependencies...
Bundler could not find compatible versions for gem "activerecord":
  In snapshot (Gemfile.lock):
    activerecord (= 5.0.0.rc1)

  In Gemfile:
    activerecord-userstamp was resolved to 3.0.4, which depends on
      activerecord (~> 5.0.0.rc1)

    paranoia (~> 2.0) was resolved to 2.0.0, which depends on
      activerecord (~> 4.0)

    rails (< 5.1, >= 5.0.0.rc1) was resolved to 5.0.0.rc1, which depends on
      activerecord (= 5.0.0.rc1)
```

Updated README.md to reflect the last pull request (which is 5.0 compatible).
