### PR TITLE
Add options for uniqueness validations. Resolves #319

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,30 @@ Client.restore(id, :recursive => true)
 client.restore(:recursive => true)
 ```
 
+If you want to validate uniqueness but want to include deleted records:
+
+``` ruby
+class Client < ActiveRecord::Base
+  acts_as_paranoid
+
+  validates :name, uniqueness: { paranoia: :with_deleted }
+
+  ...
+end
+```
+
+If you don't use the default_scope and want to validate uniqueness but want to exclude deleted records:
+
+``` ruby
+class Client < ActiveRecord::Base
+  acts_as_paranoid without_default_scope: true
+
+  validates :name, uniqueness: { paranoia: :without_deleted }
+
+  ...
+end
+```
+
 For more information, please look at the tests.
 
 #### About indexes:

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -253,6 +253,24 @@ class ParanoiaTest < test_framework
     refute b.valid?
   end
 
+  def test_uniqueness_with_deleted
+    a = ParanoidWithUniquenessWithDeleted.create!(name: "A")
+    b = ParanoidWithUniquenessWithDeleted.new(name: "A")
+    refute b.valid?
+  end
+
+  def test_uniqueness_without_default_scope_with_deleted
+    a = ParanoidWithoutDefaultScopeWithUniqueness.create!(name: "A")
+    b = ParanoidWithoutDefaultScopeWithUniqueness.new(name: "A")
+    refute b.valid?
+  end
+
+  def test_uniqueness_without_default_scope_without_deleted
+    a = ParanoidWithoutDefaultScopeWithUniquenessWithoutDeleted.create!(name: "A")
+    b = ParanoidWithoutDefaultScopeWithUniquenessWithoutDeleted.new(name: "A")
+    refute b.valid?
+  end
+
   def test_sentinel_value_for_custom_sentinel_models
     model = CustomSentinelModel.new
     assert_equal 0, model.class.count
@@ -1103,6 +1121,24 @@ class ActiveColumnModelWithUniquenessValidation < ActiveRecord::Base
       active: nil
     }
   end
+end
+
+class ParanoidWithUniquenessWithDeleted < ActiveRecord::Base
+  self.table_name = 'featureful_models'
+  acts_as_paranoid
+  validates :name, uniqueness: { paranoia: :with_deleted }
+end
+
+class ParanoidWithoutDefaultScopeWithUniqueness < ActiveRecord::Base
+  self.table_name = 'featureful_models'
+  acts_as_paranoid without_default_scope: true
+  validates :name, uniqueness: true
+end
+
+class ParanoidWithoutDefaultScopeWithUniquenessWithoutDeleted < ActiveRecord::Base
+  self.table_name = 'featureful_models'
+  acts_as_paranoid
+  validates :name, uniqueness: { paranoia: :without_deleted }
 end
 
 class NonParanoidModel < ActiveRecord::Base


### PR DESCRIPTION
For with_default_scope add a `paranoia: :with_deleted` option when you want to ensure uniqueness on all records.
For without_default_scope add a `paranoia: :without_deleted` option when you want to ensure uniqueness on only non-deleted records.
