### PR TITLE
Support multiple sentinel values

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -36,7 +36,11 @@ module Paranoia
       # these will not match != sentinel value because "NULL != value" is
       # NULL under the sql standard
       quoted_paranoia_column = connection.quote_column_name(paranoia_column)
-      with_deleted.where("#{quoted_paranoia_column} IS NULL OR #{quoted_paranoia_column} != ?", paranoia_sentinel_value)
+      if paranoia_sentinel_value.kind_of?(Array)
+        with_deleted.where("#{quoted_paranoia_column} IS NULL OR #{quoted_paranoia_column} NOT IN (?)", paranoia_sentinel_value)
+      else
+        with_deleted.where("#{quoted_paranoia_column} IS NULL OR #{quoted_paranoia_column} != ?", paranoia_sentinel_value)
+      end
     end
     alias_method :deleted, :only_deleted
 
@@ -121,7 +125,11 @@ module Paranoia
   alias :restore :restore!
 
   def paranoia_destroyed?
-    send(paranoia_column) != paranoia_sentinel_value
+    if paranoia_sentinel_value.kind_of?(Array)
+      !paranoia_sentinel_value.include?(send(paranoia_column))
+    else
+      send(paranoia_column) != paranoia_sentinel_value
+    end
   end
   alias :deleted? :paranoia_destroyed?
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -1094,7 +1094,7 @@ class StatusColumnModel < ActiveRecord::Base
   def paranoia_restore_attributes
     {
       deleted_at: nil,
-      status: 0
+      status: 1
     }
   end
 


### PR DESCRIPTION
We want to use multiple sentinel values sometimes.
For example, we use status column.

``` rb
class StatusColumnModel < ActiveRecord::Base
  # { 0 => initialized, 1: active, 2: deleted }
  acts_as_paranoid column: :status, sentinel_value: [0, 1]

  def paranoia_restore_attributes
    { deleted_at: nil, status: 0 }
  end

  def paranoia_destroy_attributes
    { deleted_at: current_time_from_proper_timezone, status: 2 }
  end
end
```

But paranoia does not support it because use `!=` operator.
We need to use `NOT IN` and `include?`.
