### PR TITLE
Fixes a problem of ambiguous table names when using only_deleted method and joining tables that have a scope on `with_deleted`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,9 @@ matrix:
     - env: RAILS='~> 5.0.0'
       rvm: 2.1.10
   allow_failures:
+    - env: RAILS='~> 4.1.15'
+      rvm: jruby-9.1.0.0
+    - env: RAILS='~> 4.2.6'
+      rvm: jruby-9.1.0.0
     - env: RAILS='~> 5.0.0'
       rvm: jruby-9.1.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,24 @@ language: ruby
 cache: bundler
 rvm:
   - 2.1.10
-  - 2.2.5
-  - 2.3.1
-  - jruby-9.1.0.0
+  - 2.2.6
+  - 2.3.3
+  - jruby-9.1.6.0
 
 env:
   matrix:
-    - RAILS='~> 4.1.15'
-    - RAILS='~> 4.2.6'
-    - RAILS='~> 5.0.0'
+    - RAILS='~> 4.1.16'
+    - RAILS='~> 4.2.7.1'
+    - RAILS='~> 5.0.0.1'
 
 matrix:
   exclude:
-    - env: RAILS='~> 5.0.0'
+    - env: RAILS='~> 5.0.0.1'
       rvm: 2.1.10
   allow_failures:
-    - env: RAILS='~> 4.1.15'
-      rvm: jruby-9.1.0.0
-    - env: RAILS='~> 4.2.6'
-      rvm: jruby-9.1.0.0
-    - env: RAILS='~> 5.0.0'
-      rvm: jruby-9.1.0.0
+    - env: RAILS='~> 4.1.16'
+      rvm: jruby-9.1.6.0
+    - env: RAILS='~> 4.2.7.1'
+      rvm: jruby-9.1.6.0
+    - env: RAILS='~> 5.0.0.1'
+      rvm: jruby-9.1.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # paranoia Changelog
 
-## 2.2.0 (unreleased)
+## 2.2.0 (2016-10-21)
 
 * Ruby 2.0 or greater is required
 * Rails 5.0.0.beta1.1 support [@pigeonworks](https://github.com/pigeonworks) [@halostatue](https://github.com/halostatue) and [@gagalago](https://github.com/gagalago)

--- a/README.md
+++ b/README.md
@@ -20,16 +20,10 @@ For Rails 3, please use version 1 of Paranoia:
 gem "paranoia", "~> 1.0"
 ```
 
-For Rails 4, please use version 2 of Paranoia:
+For Rails 4 and 5, please use version 2 of Paranoia (2.2 or greater required for rails 5):
 
 ``` ruby
-gem "paranoia", "~> 2.0"
-```
-
-For Rails 5, please use version 2.2.0.pre (pre-release):
-
-``` ruby
-gem "paranoia", "~> 2.2.0.pre"
+gem "paranoia", "~> 2.2"
 ```
 
 Of course you can install this from GitHub as well from one of these examples:

--- a/README.md
+++ b/README.md
@@ -20,10 +20,16 @@ For Rails 3, please use version 1 of Paranoia:
 gem "paranoia", "~> 1.0"
 ```
 
-For Rails 4 or 5, please use version 2 of Paranoia:
+For Rails 4, please use version 2 of Paranoia:
 
 ``` ruby
 gem "paranoia", "~> 2.0"
+```
+
+For Rails 5, please use version 2.2.0.pre (pre-release):
+
+``` ruby
+gem "paranoia", "~> 2.2.0.pre"
 ```
 
 Of course you can install this from GitHub as well from one of these examples:

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -110,7 +110,6 @@ module Paranoia
         if (noop_if_frozen && !@attributes.frozen?) || !noop_if_frozen
           write_attribute paranoia_column, paranoia_sentinel_value
           update_columns(paranoia_restore_attributes)
-          touch
         end
         restore_associated_records if opts[:recursive]
       end
@@ -154,13 +153,17 @@ module Paranoia
   def paranoia_restore_attributes
     {
       paranoia_column => paranoia_sentinel_value
-    }
+    }.merge(timestamp_attributes_with_current_time)
   end
 
   def paranoia_destroy_attributes
     {
       paranoia_column => current_time_from_proper_timezone
-    }
+    }.merge(timestamp_attributes_with_current_time)
+  end
+
+  def timestamp_attributes_with_current_time
+    timestamp_attributes_for_update_in_model.each_with_object({}) { |attr,hash| hash[attr] = current_time_from_proper_timezone }
   end
 
   # restore associated records that have been soft deleted when

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -35,8 +35,9 @@ module Paranoia
       # some deleted rows will hold a null value in the paranoia column
       # these will not match != sentinel value because "NULL != value" is
       # NULL under the sql standard
-      quoted_paranoia_column = connection.quote_column_name(paranoia_column)
-      with_deleted.where("#{quoted_paranoia_column} IS NULL OR #{quoted_paranoia_column} != ?", paranoia_sentinel_value)
+      # Scoping with the table_name is mandatory to avoid ambiguous errors when joining tables.
+      scoped_quoted_paranoia_column = "#{self.table_name}.#{connection.quote_column_name(paranoia_column)}"
+      with_deleted.where("#{scoped_quoted_paranoia_column} IS NULL OR #{scoped_quoted_paranoia_column} != ?", paranoia_sentinel_value)
     end
     alias_method :deleted, :only_deleted
 

--- a/lib/paranoia/version.rb
+++ b/lib/paranoia/version.rb
@@ -1,3 +1,3 @@
 module Paranoia
-  VERSION = "2.2.0.pre"
+  VERSION = "2.2.0"
 end

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = %w(radarlistener@gmail.com)
   s.email       = %w(ben@benmorgan.io john.hawthorn@gmail.com)
-  s.homepage    = "http://rubygems.org/gems/paranoia"
+  s.homepage    = "https://github.com/rubysherpas/paranoia"
   s.license     = 'MIT'
   s.summary     = "Paranoia is a re-implementation of acts_as_paranoid for Rails 3, 4, and 5, using much, much, much less code."
   s.description = <<-DSC

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -40,6 +40,8 @@ def setup!
     'unparanoid_unique_models' => 'name VARCHAR(32), paranoid_with_unparanoids_id INTEGER',
     'active_column_models' => 'deleted_at DATETIME, active BOOLEAN',
     'active_column_model_with_uniqueness_validations' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN',
+    'paranoid_model_with_belongs_to_active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN, active_column_model_with_has_many_relationship_id INTEGER',
+    'active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN', 
     'without_default_scope_models' => 'deleted_at DATETIME'
   }.each do |table_name, columns_as_sql_string|
     ActiveRecord::Base.connection.execute "CREATE TABLE #{table_name} (id INTEGER NOT NULL PRIMARY KEY, #{columns_as_sql_string})"
@@ -182,14 +184,28 @@ class ParanoiaTest < test_framework
     p2 = ParanoidModel.create(:parent_model => parent2)
     p1.destroy
     p2.destroy
+    
     assert_equal 0, parent1.paranoid_models.count
     assert_equal 1, parent1.paranoid_models.only_deleted.count
+
+    assert_equal 2, ParanoidModel.only_deleted.joins(:parent_model).count    
     assert_equal 1, parent1.paranoid_models.deleted.count
     assert_equal 0, parent1.paranoid_models.without_deleted.count
     p3 = ParanoidModel.create(:parent_model => parent1)
     assert_equal 2, parent1.paranoid_models.with_deleted.count
     assert_equal 1, parent1.paranoid_models.without_deleted.count
     assert_equal [p1,p3], parent1.paranoid_models.with_deleted
+  end
+
+  def test_only_deleted_with_joins
+    c1 = ActiveColumnModelWithHasManyRelationship.create(name: 'Jacky')
+    c2 = ActiveColumnModelWithHasManyRelationship.create(name: 'Thomas')
+    p1 = ParanoidModelWithBelongsToActiveColumnModelWithHasManyRelationship.create(name: 'Hello', active_column_model_with_has_many_relationship: c1)
+    
+    c1.destroy
+    assert_equal 1, ActiveColumnModelWithHasManyRelationship.count
+    assert_equal 1, ActiveColumnModelWithHasManyRelationship.only_deleted.count
+    assert_equal 1, ActiveColumnModelWithHasManyRelationship.only_deleted.joins(:paranoid_model_with_belongs_to_active_column_model_with_has_many_relationships).count
   end
 
   def test_destroy_behavior_for_custom_column_models
@@ -1095,6 +1111,45 @@ end
 
 class ActiveColumnModelWithUniquenessValidation < ActiveRecord::Base
   validates :name, :uniqueness => true
+  acts_as_paranoid column: :active, sentinel_value: true
+
+  def paranoia_restore_attributes
+    {
+      deleted_at: nil,
+      active: true
+    }
+  end
+
+  def paranoia_destroy_attributes
+    {
+      deleted_at: current_time_from_proper_timezone,
+      active: nil
+    }
+  end
+end
+
+class ActiveColumnModelWithHasManyRelationship < ActiveRecord::Base
+  has_many :paranoid_model_with_belongs_to_active_column_model_with_has_many_relationships
+  acts_as_paranoid column: :active, sentinel_value: true
+
+  def paranoia_restore_attributes
+    {
+      deleted_at: nil,
+      active: true
+    }
+  end
+
+  def paranoia_destroy_attributes
+    {
+      deleted_at: current_time_from_proper_timezone,
+      active: nil
+    }
+  end
+end
+
+class ParanoidModelWithBelongsToActiveColumnModelWithHasManyRelationship < ActiveRecord::Base
+  belongs_to :active_column_model_with_has_many_relationship
+
   acts_as_paranoid column: :active, sentinel_value: true
 
   def paranoia_restore_attributes

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -774,6 +774,13 @@ class ParanoiaTest < test_framework
     refute b.valid?
   end
 
+  def test_updated_at_modification_on_destroy
+    paranoid_model = ParanoidModelWithTimestamp.create(:parent_model => ParentModel.create, :updated_at => 1.day.ago)
+    assert paranoid_model.updated_at < 10.minutes.ago
+    paranoid_model.destroy
+    assert paranoid_model.updated_at > 10.minutes.ago
+  end
+
   def test_updated_at_modification_on_restore
     parent1 = ParentModel.create
     pt1 = ParanoidModelWithTimestamp.create(:parent_model => parent1)


### PR DESCRIPTION
Fixes #26 and #27 (that are still present). 

This bug would happen when overriding sentinel with `active` field

```
# paranoid.rb
module Paranoid
  extend ActiveSupport::Concern

  # See index section here: https://github.com/radar/paranoia

  included do
    acts_as_paranoid column: :active, sentinel_value: true
    include Overrides
  end

  # If not defined in a separate module, Paranoia will be prepended before Paranoid, causing these methods to be later
  # in the call chain
  module Overrides
    def paranoia_restore_attributes
      {
        deleted_at: nil,
        active: true
      }
    end

    def paranoia_destroy_attributes
      {
        deleted_at: current_time_from_proper_timezone,
        active: nil
      }
    end
  end
end
```

```
#post.rb
class Post < ActiveRecord::Base
    include Paranoid

    belongs_to :author, -> {with_deleted}
    belongs_to :event, -> {with_deleted}

    validates_presence_of :author, :event
end
```

```
#author.rb
class Author < ActiveRecord::Base
    include Paranoid

    has_many :posts, -> {with_deleted}, dependent: :destroy
end
```

```
#event.rb
class Event < ActiveRecord::Base
    include Paranoid

    has_many :posts, -> {with_deleted}
end
```

```
Post.only_deleted.joins(:event)
2.2.3 :001 > Post.only_deleted.joins(:event)
  Post Load (10.1ms)  SELECT "posts".* FROM "posts" INNER JOIN "events" ON "events"."id" = "posts"."event_id" AND "events"."active" = ? WHERE ("active" IS NULL OR "active" != 't')  [["active", "t"]]
ActiveRecord::StatementInvalid: SQLite3::SQLException: ambiguous column name: active: SELECT "posts".* FROM "posts" INNER JOIN "events" ON "events"."id" = "posts"."event_id" AND "events"."active" = ? WHERE ("active" IS NULL OR "active" != 't')
```
