### PR TITLE
[CI SKIP] Update homepage

### DIFF
--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = %w(radarlistener@gmail.com)
   s.email       = %w(ben@benmorgan.io john.hawthorn@gmail.com)
-  s.homepage    = "http://rubygems.org/gems/paranoia"
+  s.homepage    = "https://github.com/rubysherpas/paranoia"
   s.license     = 'MIT'
   s.summary     = "Paranoia is a re-implementation of acts_as_paranoid for Rails 3, 4, and 5, using much, much, much less code."
   s.description = <<-DSC


### PR DESCRIPTION
The homepage is supposed to be where you can find the code. It is displayed on rubygems.org page. Currently it will redirect you back to the same page. Should point at this github repo.
