### PR TITLE
Fix counter cache double decrement problem.

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -74,30 +74,29 @@ module Paranoia
 
   def destroy
     transaction do
+      add_to_transaction
       run_callbacks(:destroy) do
-        result = delete
-        next result unless result && ActiveRecord::VERSION::STRING >= '4.2'
-        each_counter_cached_associations do |association|
-          foreign_key = association.reflection.foreign_key.to_sym
-          next if destroyed_by_association && destroyed_by_association.foreign_key.to_sym == foreign_key
-          next unless send(association.reflection.name)
-          association.decrement_counters
+        raise ActiveRecord::ReadOnlyRecord, "#{self.class} is marked as readonly" if readonly?
+        affected_records = paranoia_destroy_row
+        next self unless ActiveRecord::VERSION::STRING >= '4.2'
+        if affected_records > 0
+          each_counter_cached_associations do |association|
+            foreign_key = association.reflection.foreign_key.to_sym
+            next if destroyed_by_association && destroyed_by_association.foreign_key.to_sym == foreign_key
+            next unless send(association.reflection.name)
+            association.decrement_counters
+          end
         end
-        result
+        self
       end
     end
   end
 
   def delete
-    raise ActiveRecord::ReadOnlyRecord, "#{self.class} is marked as readonly" if readonly?
-    if persisted?
-      # if a transaction exists, add the record so that after_commit
-      # callbacks can be run
-      add_to_transaction
-      update_columns(paranoia_destroy_attributes)
-    elsif !frozen?
-      assign_attributes(paranoia_destroy_attributes)
-    end
+    # if a transaction exists, add the record so that after_commit
+    # callbacks can be run
+    add_to_transaction if persisted?
+    paranoia_destroy_row
     self
   end
 
@@ -202,6 +201,33 @@ module Paranoia
     end
 
     clear_association_cache if destroyed_associations.present?
+  end
+
+  def paranoia_destroy_row
+    attributes = paranoia_destroy_attributes
+
+    if persisted?
+      model = self.class
+      primary_key = model.primary_key
+      affected_records = model
+                         .unscoped
+                         .without_deleted
+                         .where(primary_key => self[primary_key])
+                         .update_all(attributes)
+
+      if affected_records > 0
+        attributes.each do |k, v|
+          raw_write_attribute(k, v)
+        end
+      end
+
+      affected_records
+    elsif !frozen?
+      assign_attributes(attributes)
+      1
+    else
+      0
+    end
   end
 end
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -889,6 +889,22 @@ class ParanoiaTest < test_framework
     assert_equal 0, parent_model_with_counter_cache_column.reload.related_models_count
   end
 
+  # TODO: it seems impossible to fix double decrement on Rails < 4.2
+  #       because in these versions decrement on destroy
+  #       is being performed in before_destroy callback :(
+  if ActiveRecord::VERSION::STRING >= "4.2"
+    def test_counter_cache_column_update_on_double_destroy
+      parent_model_with_counter_cache_column = ParentModelWithCounterCacheColumn.create
+      related_model1 = parent_model_with_counter_cache_column.related_models.create
+      related_model2 = parent_model_with_counter_cache_column.related_models.find(related_model1.id)
+
+      assert_equal 1, parent_model_with_counter_cache_column.reload.related_models_count
+      related_model1.destroy
+      related_model2.destroy
+      assert_equal 0, parent_model_with_counter_cache_column.reload.related_models_count
+    end
+  end
+
   def test_callbacks_for_counter_cache_column_update_on_destroy
     parent_model_with_counter_cache_column = ParentModelWithCounterCacheColumn.create
     related_model = parent_model_with_counter_cache_column.related_models.create


### PR DESCRIPTION
Sometimes paranoia could decrement counter cache twice even if record is already destroyed.

In our app we have invalid counter cache column values, internal investigation showed that it was due to race condition while destroying the same record (double-click on the 'delete' button).