### PR TITLE
Touch record on paranoia-destroy. Fixes #296

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -110,7 +110,6 @@ module Paranoia
         if (noop_if_frozen && !@attributes.frozen?) || !noop_if_frozen
           write_attribute paranoia_column, paranoia_sentinel_value
           update_columns(paranoia_restore_attributes)
-          touch
         end
         restore_associated_records if opts[:recursive]
       end
@@ -154,13 +153,17 @@ module Paranoia
   def paranoia_restore_attributes
     {
       paranoia_column => paranoia_sentinel_value
-    }
+    }.merge(timestamp_attributes_with_current_time)
   end
 
   def paranoia_destroy_attributes
     {
       paranoia_column => current_time_from_proper_timezone
-    }
+    }.merge(timestamp_attributes_with_current_time)
+  end
+
+  def timestamp_attributes_with_current_time
+    timestamp_attributes_for_update_in_model.each_with_object({}) { |attr,hash| hash[attr] = current_time_from_proper_timezone }
   end
 
   # restore associated records that have been soft deleted when

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -774,6 +774,13 @@ class ParanoiaTest < test_framework
     refute b.valid?
   end
 
+  def test_updated_at_modification_on_destroy
+    paranoid_model = ParanoidModelWithTimestamp.create(:parent_model => ParentModel.create, :updated_at => 1.day.ago)
+    assert paranoid_model.updated_at < 10.minutes.ago
+    paranoid_model.destroy
+    assert paranoid_model.updated_at > 10.minutes.ago
+  end
+
   def test_updated_at_modification_on_restore
     parent1 = ParentModel.create
     pt1 = ParanoidModelWithTimestamp.create(:parent_model => parent1)


### PR DESCRIPTION
Touch record on destroy by leveraging the paranoia_destroy_attributes.
Applied the same to the restore-method as this eliminates the extra query.

As pointed out by @ccleung in #296, touch on destroy was broken in #245 / b2b8d19 (verified by running the included test against 2.1.3 and 2.1.4). Since update_columns is used now (reasons are pointed out in that commit), update-timestamps were no longer set by ActiveRecord.

(Recreation of PR #311, as PR-repo was gone so no new commits could be pushed.)