### PR TITLE
Fixes a problem of ambiguous table names when using only_deleted meth…

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -35,8 +35,9 @@ module Paranoia
       # some deleted rows will hold a null value in the paranoia column
       # these will not match != sentinel value because "NULL != value" is
       # NULL under the sql standard
-      quoted_paranoia_column = connection.quote_column_name(paranoia_column)
-      with_deleted.where("#{quoted_paranoia_column} IS NULL OR #{quoted_paranoia_column} != ?", paranoia_sentinel_value)
+      # Scoping with the table_name is mandatory to avoid ambiguous errors when joining tables.
+      scoped_quoted_paranoia_column = "#{self.table_name}.#{connection.quote_column_name(paranoia_column)}"
+      with_deleted.where("#{scoped_quoted_paranoia_column} IS NULL OR #{scoped_quoted_paranoia_column} != ?", paranoia_sentinel_value)
     end
     alias_method :deleted, :only_deleted
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -40,6 +40,8 @@ def setup!
     'unparanoid_unique_models' => 'name VARCHAR(32), paranoid_with_unparanoids_id INTEGER',
     'active_column_models' => 'deleted_at DATETIME, active BOOLEAN',
     'active_column_model_with_uniqueness_validations' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN',
+    'paranoid_model_with_belongs_to_active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN, active_column_model_with_has_many_relationship_id INTEGER',
+    'active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN', 
     'without_default_scope_models' => 'deleted_at DATETIME'
   }.each do |table_name, columns_as_sql_string|
     ActiveRecord::Base.connection.execute "CREATE TABLE #{table_name} (id INTEGER NOT NULL PRIMARY KEY, #{columns_as_sql_string})"
@@ -182,14 +184,28 @@ class ParanoiaTest < test_framework
     p2 = ParanoidModel.create(:parent_model => parent2)
     p1.destroy
     p2.destroy
+    
     assert_equal 0, parent1.paranoid_models.count
     assert_equal 1, parent1.paranoid_models.only_deleted.count
+
+    assert_equal 2, ParanoidModel.only_deleted.joins(:parent_model).count    
     assert_equal 1, parent1.paranoid_models.deleted.count
     assert_equal 0, parent1.paranoid_models.without_deleted.count
     p3 = ParanoidModel.create(:parent_model => parent1)
     assert_equal 2, parent1.paranoid_models.with_deleted.count
     assert_equal 1, parent1.paranoid_models.without_deleted.count
     assert_equal [p1,p3], parent1.paranoid_models.with_deleted
+  end
+
+  def test_only_deleted_with_joins
+    c1 = ActiveColumnModelWithHasManyRelationship.create(name: 'Jacky')
+    c2 = ActiveColumnModelWithHasManyRelationship.create(name: 'Thomas')
+    p1 = ParanoidModelWithBelongsToActiveColumnModelWithHasManyRelationship.create(name: 'Hello', active_column_model_with_has_many_relationship: c1)
+    
+    c1.destroy
+    assert_equal 1, ActiveColumnModelWithHasManyRelationship.count
+    assert_equal 1, ActiveColumnModelWithHasManyRelationship.only_deleted.count
+    assert_equal 1, ActiveColumnModelWithHasManyRelationship.only_deleted.joins(:paranoid_model_with_belongs_to_active_column_model_with_has_many_relationships).count
   end
 
   def test_destroy_behavior_for_custom_column_models
@@ -1095,6 +1111,45 @@ end
 
 class ActiveColumnModelWithUniquenessValidation < ActiveRecord::Base
   validates :name, :uniqueness => true
+  acts_as_paranoid column: :active, sentinel_value: true
+
+  def paranoia_restore_attributes
+    {
+      deleted_at: nil,
+      active: true
+    }
+  end
+
+  def paranoia_destroy_attributes
+    {
+      deleted_at: current_time_from_proper_timezone,
+      active: nil
+    }
+  end
+end
+
+class ActiveColumnModelWithHasManyRelationship < ActiveRecord::Base
+  has_many :paranoid_model_with_belongs_to_active_column_model_with_has_many_relationships
+  acts_as_paranoid column: :active, sentinel_value: true
+
+  def paranoia_restore_attributes
+    {
+      deleted_at: nil,
+      active: true
+    }
+  end
+
+  def paranoia_destroy_attributes
+    {
+      deleted_at: current_time_from_proper_timezone,
+      active: nil
+    }
+  end
+end
+
+class ParanoidModelWithBelongsToActiveColumnModelWithHasManyRelationship < ActiveRecord::Base
+  belongs_to :active_column_model_with_has_many_relationship
+
   acts_as_paranoid column: :active, sentinel_value: true
 
   def paranoia_restore_attributes


### PR DESCRIPTION
Fixes #26 and #27 (that are still present). 

This bug would happen when overriding sentinel with `active` field

```
# paranoid.rb
module Paranoid
  extend ActiveSupport::Concern

  # See index section here: https://github.com/radar/paranoia

  included do
    acts_as_paranoid column: :active, sentinel_value: true
    include Overrides
  end

  # If not defined in a separate module, Paranoia will be prepended before Paranoid, causing these methods to be later
  # in the call chain
  module Overrides
    def paranoia_restore_attributes
      {
        deleted_at: nil,
        active: true
      }
    end

    def paranoia_destroy_attributes
      {
        deleted_at: current_time_from_proper_timezone,
        active: nil
      }
    end
  end
end
```

```
#post.rb
class Post < ActiveRecord::Base
    include Paranoid

    belongs_to :author, -> {with_deleted}
    belongs_to :event, -> {with_deleted}

    validates_presence_of :author, :event
end
```

```
#author.rb
class Author < ActiveRecord::Base
    include Paranoid

    has_many :posts, -> {with_deleted}, dependent: :destroy
end
```

```
#event.rb
class Event < ActiveRecord::Base
    include Paranoid

    has_many :posts, -> {with_deleted}
end
```

```
Post.only_deleted.joins(:event)
2.2.3 :001 > Post.only_deleted.joins(:event)
  Post Load (10.1ms)  SELECT "posts".* FROM "posts" INNER JOIN "events" ON "events"."id" = "posts"."event_id" AND "events"."active" = ? WHERE ("active" IS NULL OR "active" != 't')  [["active", "t"]]
ActiveRecord::StatementInvalid: SQLite3::SQLException: ambiguous column name: active: SELECT "posts".* FROM "posts" INNER JOIN "events" ON "events"."id" = "posts"."event_id" AND "events"."active" = ? WHERE ("active" IS NULL OR "active" != 't')
```