### PR TITLE
Add recovery window feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ Client.restore(id, :recursive => true)
 client.restore(:recursive => true)
 ```
 
+If you want to restore a record and only those dependently destroyed associated records that were deleted within 2 minutes of the object upon which they depend:
+
+``` ruby
+Client.restore(id, :recursive => true. :recovery_window => 2.minutes)
+# or
+client.restore(:recursive => true, :recovery_window => 2.minutes)
+```
+
 For more information, please look at the tests.
 
 #### About indexes:


### PR DESCRIPTION
Resolves #359.

Adds option to restore only those dependently destroyed associated records that were deleted within a timespan - before or after the object upon which they depend. The `:recovery_window` param is added to `restore` method to define the timespan.

The default behaviour is not modified, so not defining `:recovery_window` restores everything.