### PR TITLE
Fix UniquenessParanoiaValidator on rails 5.1.0.beta1

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -284,8 +284,8 @@ require 'paranoia/rspec' if defined? RSpec
 module ActiveRecord
   module Validations
     module UniquenessParanoiaValidator
-      def build_relation(klass, table, attribute, value)
-        relation = super(klass, table, attribute, value)
+      def build_relation(klass, *args)
+        relation = super
         return relation unless klass.respond_to?(:paranoia_column)
         arel_paranoia_scope = klass.arel_table[klass.paranoia_column].eq(klass.paranoia_sentinel_value)
         if ActiveRecord::VERSION::STRING >= "5.0"


### PR DESCRIPTION
The number of arguments to `build_relation` has changed. Fortunately, we only use the first argument and it hasn't changed.

I didn't add 5.1.0.beta1 to the `.travis.yml`, as there are bound to be major changes in the upcoming beta versions. But the specs do pass when running `RAILS=5.1.0.beta1 rake`