### PR TITLE
Changelog: Add missing bang in `#really_destroy!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 
 * `#destroyed?` is no longer overridden. Use `#paranoia_destroyed?` for the existing behaviour. [Washington Luiz](https://github.com/huoxito)
 * `#persisted?` is no longer overridden.
-* ActiveRecord 4.0 no longer has `#destroy!` as an alias for `#really_destroy`.
+* ActiveRecord 4.0 no longer has `#destroy!` as an alias for `#really_destroy!`.
 * `#destroy` will now raise an exception if called on a readonly record.
 * `#destroy` on a hard deleted record is now a successful noop.
 * `#destroy` on a new record will set deleted_at (previously this raised an error)
@@ -60,7 +60,7 @@
 
 ### Bug Fixes
 
-* Calling `#destroy` twice will not hard-delete records. Use `#really_destroy` if this is desired.
+* Calling `#destroy` twice will not hard-delete records. Use `#really_destroy!` if this is desired.
 * Fix errors on non-paranoid has_one dependent associations
 
 ## 2.0.5 (2015-01-22)


### PR DESCRIPTION
Also, it might be a good idea to change this to "acts_as_paranoid for Rails 3, 4 & 5."

![screenshot 2017-03-01 14 28 04](https://cloud.githubusercontent.com/assets/1735266/23487396/aea67b58-fe9a-11e6-8598-9f5e3ee08139.png)
