### PR TITLE
Added association not soft destroyed validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2.2.2 (Unreleased)
 
+* [#389](https://github.com/rubysherpas/paranoia/pull/389) Added association not soft destroyed validator
+
+  _Fixes [#380](https://github.com/rubysherpas/paranoia/issues/380)_
+
+  [Edward Poot (@edwardmp)](https://github.com/edwardmp)
+
 ## 2.2.1 (2017-02-15)
 
 * [#371](https://github.com/rubysherpas/paranoia/pull/371) Use ActiveSupport.on_load to correctly re-open ActiveRecord::Base

--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ Client.restore(id, :recursive => true. :recovery_window => 2.minutes)
 client.restore(:recursive => true, :recovery_window => 2.minutes)
 ```
 
+Note that by default paranoia will not prevent that a soft destroyed object can't be associated with another object of a different model.
+A Rails validator is provided should you require this functionality:
+  ``` ruby
+validates :some_assocation, association_not_soft_destroyed: true
+```
+This validator makes sure that `some_assocation` is not soft destroyed. If the object is soft destroyed the main object is rendered invalid and an validation error is added.
+
 For more information, please look at the tests.
 
 #### About indexes:

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -299,5 +299,14 @@ module ActiveRecord
     class UniquenessValidator < ActiveModel::EachValidator
       prepend UniquenessParanoiaValidator
     end
+    
+    class AssociationNotSoftDestroyedValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value)
+        # if association is soft destroyed, add an error
+        if value.present? && value.deleted?
+          record.errors[attribute] << 'has been soft-deleted'
+        end
+      end
+    end
   end
 end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -118,9 +118,9 @@ class ParanoiaTest < test_framework
     model.remove_called_variables     # clear called callback flags
     model.destroy
 
-    assert_equal nil, model.instance_variable_get(:@update_callback_called)
-    assert_equal nil, model.instance_variable_get(:@save_callback_called)
-    assert_equal nil, model.instance_variable_get(:@validate_called)
+    assert_nil model.instance_variable_get(:@update_callback_called)
+    assert_nil model.instance_variable_get(:@save_callback_called)
+    assert_nil model.instance_variable_get(:@validate_called)
 
     assert model.instance_variable_get(:@destroy_callback_called)
     assert model.instance_variable_get(:@after_destroy_callback_called)
@@ -134,12 +134,12 @@ class ParanoiaTest < test_framework
     model.remove_called_variables     # clear called callback flags
     model.delete
 
-    assert_equal nil, model.instance_variable_get(:@update_callback_called)
-    assert_equal nil, model.instance_variable_get(:@save_callback_called)
-    assert_equal nil, model.instance_variable_get(:@validate_called)
-    assert_equal nil, model.instance_variable_get(:@destroy_callback_called)
-    assert_equal nil, model.instance_variable_get(:@after_destroy_callback_called)
-    assert_equal nil, model.instance_variable_get(:@after_commit_callback_called)
+    assert_nil model.instance_variable_get(:@update_callback_called)
+    assert_nil model.instance_variable_get(:@save_callback_called)
+    assert_nil model.instance_variable_get(:@validate_called)
+    assert_nil model.instance_variable_get(:@destroy_callback_called)
+    assert_nil model.instance_variable_get(:@after_destroy_callback_called)
+    assert_nil model.instance_variable_get(:@after_commit_callback_called)
   end
 
   def test_delete_in_transaction_behavior_for_plain_models_callbacks
@@ -150,11 +150,11 @@ class ParanoiaTest < test_framework
       model.delete
     end
 
-    assert_equal nil, model.instance_variable_get(:@update_callback_called)
-    assert_equal nil, model.instance_variable_get(:@save_callback_called)
-    assert_equal nil, model.instance_variable_get(:@validate_called)
-    assert_equal nil, model.instance_variable_get(:@destroy_callback_called)
-    assert_equal nil, model.instance_variable_get(:@after_destroy_callback_called)
+    assert_nil model.instance_variable_get(:@update_callback_called)
+    assert_nil model.instance_variable_get(:@save_callback_called)
+    assert_nil model.instance_variable_get(:@validate_called)
+    assert_nil model.instance_variable_get(:@destroy_callback_called)
+    assert_nil model.instance_variable_get(:@after_destroy_callback_called)
     assert model.instance_variable_get(:@after_commit_callback_called)
   end
 
@@ -227,7 +227,7 @@ class ParanoiaTest < test_framework
   end
 
   def test_default_sentinel_value
-    assert_equal nil, ParanoidModel.paranoia_sentinel_value
+    assert_nil ParanoidModel.paranoia_sentinel_value
   end
 
   def test_without_default_scope_option
@@ -376,7 +376,7 @@ class ParanoiaTest < test_framework
     model = CallbackModel.new
     model.save
     model.delete
-    assert_equal nil, model.instance_variable_get(:@destroy_callback_called)
+    assert_nil model.instance_variable_get(:@destroy_callback_called)
   end
 
   def test_destroy_behavior_for_callbacks
@@ -949,8 +949,8 @@ class ParanoiaTest < test_framework
     parent_model_with_counter_cache_column = ParentModelWithCounterCacheColumn.create
     related_model = parent_model_with_counter_cache_column.related_models.create
 
-    assert_equal nil, related_model.instance_variable_get(:@after_destroy_callback_called)
-    assert_equal nil, related_model.instance_variable_get(:@after_commit_on_destroy_callback_called)
+    assert_nil related_model.instance_variable_get(:@after_destroy_callback_called)
+    assert_nil related_model.instance_variable_get(:@after_commit_on_destroy_callback_called)
 
     related_model.destroy
 
@@ -995,8 +995,8 @@ class ParanoiaTest < test_framework
       parent_model_with_counter_cache_column = ParentModelWithCounterCacheColumn.create
       related_model = parent_model_with_counter_cache_column.related_models.create
 
-      assert_equal nil, related_model.instance_variable_get(:@after_destroy_callback_called)
-      assert_equal nil, related_model.instance_variable_get(:@after_commit_on_destroy_callback_called)
+      assert_nil related_model.instance_variable_get(:@after_destroy_callback_called)
+      assert_nil related_model.instance_variable_get(:@after_commit_on_destroy_callback_called)
 
       related_model.really_destroy!
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -1283,7 +1283,6 @@ class NotParanoidModelWithBelongsAndAssocationNotSoftDestroyedValidator < NotPar
     validates :parent_model, association_not_soft_destroyed: true
 end
 
-
 class FlaggedModel < PlainModel
   acts_as_paranoid :flag_column => :is_deleted
 end


### PR DESCRIPTION
See #380. 

While we're at it I also included some changes so the following warning doesn't show up anymore:
`Use assert_nil if expecting nil from [..]. This will fail in MT6.`