### PR TITLE
Fix counter cache with double destroy, really_destroy, and restore

### DIFF
--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -1003,6 +1003,44 @@ class ParanoiaTest < test_framework
       assert related_model.instance_variable_get(:@after_destroy_callback_called)
       assert related_model.instance_variable_get(:@after_commit_on_destroy_callback_called)
     end
+
+    def test_counter_cache_column_on_double_destroy
+      parent_model_with_counter_cache_column = ParentModelWithCounterCacheColumn.create
+      related_model = parent_model_with_counter_cache_column.related_models.create
+
+      related_model.destroy
+      related_model.destroy
+      assert_equal 0, parent_model_with_counter_cache_column.reload.related_models_count
+    end
+
+    def test_counter_cache_column_on_double_restore
+      parent_model_with_counter_cache_column = ParentModelWithCounterCacheColumn.create
+      related_model = parent_model_with_counter_cache_column.related_models.create
+
+      related_model.destroy
+      related_model.restore
+      related_model.restore
+      assert_equal 1, parent_model_with_counter_cache_column.reload.related_models_count
+    end
+
+    def test_counter_cache_column_on_destroy_and_really_destroy
+      parent_model_with_counter_cache_column = ParentModelWithCounterCacheColumn.create
+      related_model = parent_model_with_counter_cache_column.related_models.create
+
+      related_model.destroy
+      related_model.really_destroy!
+      assert_equal 0, parent_model_with_counter_cache_column.reload.related_models_count
+    end
+
+    def test_counter_cache_column_on_restore
+      parent_model_with_counter_cache_column = ParentModelWithCounterCacheColumn.create
+      related_model = parent_model_with_counter_cache_column.related_models.create
+
+      related_model.destroy
+      assert_equal 0, parent_model_with_counter_cache_column.reload.related_models_count
+      related_model.restore
+      assert_equal 1, parent_model_with_counter_cache_column.reload.related_models_count
+    end
   end
 
   private


### PR DESCRIPTION
There's several cases where counter caches get out of sync with soft deletes. This patch gives the ability to disable counter caches for certain events so that the counter caches automatically reflect the correct count.

1. If you destroy a record multiple times, it will decrement the count multiple times.
2. If you soft destroy a record and then permanently destroy it, it will decrement multiple times.
3. Restore does not increment the count.

This checks to see if a record has already been soft deleted when doing a `destroy` or `really_destroy!` and then disables the counter cache decrement if it was already soft deleted.

It also adds an increment to the `restore` method which is the same as the CounterCache create inside ActiveRecord.

Tested this on both Rails 4.2.8 and 5.0.2 and everything looks to be working correctly.