### PR TITLE
Open support for Rails 5.1.x.

### DIFF
--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'activerecord', '>= 4.0', '< 5.1'
+  s.add_dependency 'activerecord', '>= 4.0', '< 5.2'
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake"


### PR DESCRIPTION
Hi,

Ruby on Rails 5.1 is available now but the `gemspec` blocks the update on a stable version.

I tested on my project and everything works like on 5.1.0.rc2.

Best regards.