### PR TITLE
Update readme to reflect problem with eager loading in Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,16 +123,6 @@ def product
 end
 ```
 
-If you want to include associated soft-deleted objects, you can (un)scope the association:
-
-``` ruby
-class Person < ActiveRecord::Base
-  belongs_to :group, -> { with_deleted }
-end
-
-Person.includes(:group).all
-```
-
 If you want to find all records, even those which are deleted:
 
 ``` ruby


### PR DESCRIPTION
[Rails eager loading does not work when association methods like `has_many` override the default scope](https://github.com/rails/rails/issues/11036)

The example in the readme won't actually eager load the association properly. It will include the association with the default scope, and then make an additional query whenever you try to access the unscoped version

In order to properly eager-load the association, you have to set `use_default_scope: false` and then scope the association manually wherever you need it scoped