### PR TITLE
⚠ instance variable @_disable_counter_cache not initialized

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -174,7 +174,7 @@ module Paranoia
   private
 
   def each_counter_cached_associations
-    !(defined?(@_disable_counter_cache) && @_disable_counter_cache) && defined?(super) ? super : []
+    !(defined?(@_disable_counter_cache) && @_disable_counter_cache) ? super : []
   end
 
   def paranoia_restore_attributes

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -174,7 +174,7 @@ module Paranoia
   private
 
   def each_counter_cached_associations
-    !@_disable_counter_cache && defined?(super) ? super : []
+    !(defined?(@_disable_counter_cache) && @_disable_counter_cache) && defined?(super) ? super : []
   end
 
   def paranoia_restore_attributes


### PR DESCRIPTION
Here's a fix for a trivial Ruby-level warning.