### PR TITLE
Enable .with_deleted to accept a block

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -21,10 +21,13 @@ module Paranoia
     def paranoid? ; true ; end
 
     def with_deleted
-      if ActiveRecord::VERSION::STRING >= "4.1"
-        return unscope where: paranoia_column
+      if block_given?
+        unscoped { yield }
+      elsif ActiveRecord::VERSION::STRING >= "4.1"
+        unscope where: paranoia_column
+      else
+        all.tap { |x| x.default_scoped = false }
       end
-      all.tap { |x| x.default_scoped = false }
     end
 
     def only_deleted
@@ -313,7 +316,7 @@ module ActiveRecord
     class UniquenessValidator < ActiveModel::EachValidator
       prepend UniquenessParanoiaValidator
     end
-    
+
     class AssociationNotSoftDestroyedValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
         # if association is soft destroyed, add an error

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -42,7 +42,7 @@ def setup!
     'active_column_models' => 'deleted_at DATETIME, active BOOLEAN',
     'active_column_model_with_uniqueness_validations' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN',
     'paranoid_model_with_belongs_to_active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN, active_column_model_with_has_many_relationship_id INTEGER',
-    'active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN', 
+    'active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN',
     'without_default_scope_models' => 'deleted_at DATETIME'
   }.each do |table_name, columns_as_sql_string|
     ActiveRecord::Base.connection.execute "CREATE TABLE #{table_name} (id INTEGER NOT NULL PRIMARY KEY, #{columns_as_sql_string})"
@@ -185,24 +185,26 @@ class ParanoiaTest < test_framework
     p2 = ParanoidModel.create(:parent_model => parent2)
     p1.destroy
     p2.destroy
-    
+
     assert_equal 0, parent1.paranoid_models.count
     assert_equal 1, parent1.paranoid_models.only_deleted.count
 
-    assert_equal 2, ParanoidModel.only_deleted.joins(:parent_model).count    
+    assert_equal 2, ParanoidModel.only_deleted.joins(:parent_model).count
     assert_equal 1, parent1.paranoid_models.deleted.count
     assert_equal 0, parent1.paranoid_models.without_deleted.count
     p3 = ParanoidModel.create(:parent_model => parent1)
     assert_equal 2, parent1.paranoid_models.with_deleted.count
+    assert_equal 2, ParanoidModel.with_deleted { parent1.paranoid_models.count }
     assert_equal 1, parent1.paranoid_models.without_deleted.count
     assert_equal [p1,p3], parent1.paranoid_models.with_deleted
+    assert_equal [p1,p3], ParanoidModel.with_deleted { parent1.paranoid_models.to_a }
   end
 
   def test_only_deleted_with_joins
     c1 = ActiveColumnModelWithHasManyRelationship.create(name: 'Jacky')
     c2 = ActiveColumnModelWithHasManyRelationship.create(name: 'Thomas')
     p1 = ParanoidModelWithBelongsToActiveColumnModelWithHasManyRelationship.create(name: 'Hello', active_column_model_with_has_many_relationship: c1)
-    
+
     c1.destroy
     assert_equal 1, ActiveColumnModelWithHasManyRelationship.count
     assert_equal 1, ActiveColumnModelWithHasManyRelationship.only_deleted.count


### PR DESCRIPTION
Because calling .unscoped directly is less intuitive / memorable.

Some considerations:
* Is `.with_deleted` less clear than `.unscoped`?
* Is it problematic that the other scopes don't accept a block?

IMO this is useful and worthwhile, I put it forward for the sake of conversation / consideration.
