### PR TITLE
Fixes `really_destroy!` behavior with `sentinel_value`

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -165,7 +165,7 @@ module Paranoia
             association_data.really_destroy!
           end
         end
-        write_attribute(paranoia_column, current_time_from_proper_timezone)
+        update_columns(paranoia_destroy_attributes)
         destroy_without_paranoia
       end
     end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -546,6 +546,14 @@ class ParanoiaTest < test_framework
     assert model.instance_variable_get(:@real_destroy_callback_called)
   end
 
+  def test_really_destroy_behavior_for_active_column_model
+    model = ActiveColumnModel.new
+    model.save
+    model.really_destroy!
+
+    refute ParanoidModel.unscoped.exists?(model.id)
+  end
+
   def test_really_delete
     model = ParanoidModel.new
     model.save


### PR DESCRIPTION
This removes the assumption from `really_destroy!` that there is
only one column value, the deletion date, that needs to be updated
on a model that is being `really_destroy!`ed. Instead, use the
defined `paranoia_destroy_attributes` as they are used in `destroy`
and other calls.

This prevents an issue where the DBMS will complain when trying to
`really_destroy!` one of these models, given that paranoia is
attempting to insert a DateTime value into a boolean (or otherly-
typed) column.

Fixes #326