### PR TITLE
Feature/dirty tracking

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -147,10 +147,10 @@ module Paranoia
   alias :deleted? :paranoia_destroyed?
 
   def paranoia_update_columns(attributes)
+    update_columns(attributes)
     attributes.keys.each do |key|
       send("#{key}_will_change!")
     end
-    update_columns(attributes)
     changes_applied
   end
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -97,7 +97,7 @@ module Paranoia
       # if a transaction exists, add the record so that after_commit
       # callbacks can be run
       add_to_transaction
-      update_columns(paranoia_destroy_attributes)
+      paranoia_update_columns(paranoia_destroy_attributes)
     elsif !frozen?
       assign_attributes(paranoia_destroy_attributes)
     end
@@ -114,7 +114,7 @@ module Paranoia
         if within_recovery_window?(recovery_window_range) && ((noop_if_frozen && !@attributes.frozen?) || !noop_if_frozen)
           @_disable_counter_cache = !deleted?
           write_attribute paranoia_column, paranoia_sentinel_value
-          update_columns(paranoia_restore_attributes)
+          paranoia_update_columns(paranoia_restore_attributes)
           each_counter_cached_associations do |association|
             if send(association.reflection.name)
               association.increment_counters
@@ -145,6 +145,14 @@ module Paranoia
     send(paranoia_column) != paranoia_sentinel_value
   end
   alias :deleted? :paranoia_destroyed?
+
+  def paranoia_update_columns(attributes)
+    attributes.keys.each do |key|
+      send("#{key}_will_change!")
+    end
+    update_columns(attributes)
+    changes_applied
+  end
 
   def really_destroy!
     transaction do

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -178,6 +178,13 @@ class ParanoiaTest < test_framework
     assert record.update_columns deleted_at: Time.now
   end
 
+  def test_dirty_tracking_on_paranoia_destroyed
+    record = ParentModel.create
+    record.destroy
+
+    assert_equal record.previous_changes.keys, ["deleted_at"]
+  end
+
   def test_scoping_behavior_for_paranoid_models
     parent1 = ParentModel.create
     parent2 = ParentModel.create
@@ -226,6 +233,13 @@ class ParanoiaTest < test_framework
     assert_equal 1, model.class.deleted.count
   end
 
+  def test_dirty_tracking_for_custom_column_models
+    record = CustomColumnModel.create
+    record.destroy
+
+    assert_equal record.previous_changes.keys, ["destroyed_at"]
+  end
+
   def test_default_sentinel_value
     assert_nil ParanoidModel.paranoia_sentinel_value
   end
@@ -255,6 +269,12 @@ class ParanoiaTest < test_framework
     assert_equal 1, model.class.unscoped.count
     assert_equal 1, model.class.only_deleted.count
     assert_equal 1, model.class.deleted.count
+  end
+
+  def test_dirty_tracking_for_active_column_model
+    record = ActiveColumnModel.create
+    record.destroy
+    assert_equal record.previous_changes.keys, ["deleted_at", "active"]
   end
 
   def test_active_column_model_with_uniqueness_validation_only_checks_non_deleted_records
@@ -441,6 +461,17 @@ class ParanoiaTest < test_framework
     model.reload
 
     assert_equal false, model.paranoia_destroyed?
+  end
+
+  def test_dirty_tracking_on_restore
+    model = ParanoidModel.new
+    model.save
+    id = model.id
+    model.destroy
+
+    model = ParanoidModel.only_deleted.find(id)
+    model.restore!
+    assert_equal model.previous_changes.keys, ['deleted_at']
   end
 
   def test_restore_on_object_return_self


### PR DESCRIPTION
I took what the first commit from https://github.com/rubysherpas/paranoia/pull/375

As far as I understood, `update_columns` does not track changes with `Dirty` because it does not use the regular attribute setters, it uses `raw_write_attribute`. `raw_write_attribute` also clears the changes in 5.1.x. See [here](https://github.com/rails/rails/blob/v5.1.3/activerecord/lib/active_record/attribute_methods/dirty.rb#L86) (which is called from `update_columns`. `super` is in [persistence](https://github.com/rails/rails/blob/v5.1.3/activerecord/lib/active_record/persistence.rb#L325)).

Adding `deleted_at_will_change!` and `changes_applied` works except for rails 5.0.x, couldn't find the reason. It looks like the [AttributeMutationTracker](https://github.com/rails/rails/blob/v5.0.5/activerecord/lib/active_record/attribute_mutation_tracker.rb) does not track the change in `deleted_at` correctly
