### PR TITLE
Add paranoia_destroy and paranoia_delete aliases

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -52,7 +52,7 @@ module Paranoia
     end
   end
 
-  def destroy
+  def paranoia_destroy
     transaction do
       run_callbacks(:destroy) do
         @_disable_counter_cache = deleted?
@@ -69,8 +69,9 @@ module Paranoia
       end
     end
   end
+  alias_method :destroy, :paranoia_destroy
 
-  def delete
+  def paranoia_delete
     raise ActiveRecord::ReadOnlyRecord, "#{self.class} is marked as readonly" if readonly?
     if persisted?
       # if a transaction exists, add the record so that after_commit
@@ -82,6 +83,7 @@ module Paranoia
     end
     self
   end
+  alias_method :delete, :paranoia_delete
 
   def restore!(opts = {})
     self.class.transaction do

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -14,7 +14,6 @@ module Paranoia
 
   def self.included(klazz)
     klazz.extend Query
-    klazz.extend Callbacks
   end
 
   module Query
@@ -50,26 +49,6 @@ module Paranoia
                                         "Please pass the id of the object by calling `.id`")
       end
       ids.map { |id| only_deleted.find(id).restore!(opts) }
-    end
-  end
-
-  module Callbacks
-    def self.extended(klazz)
-      [:restore, :real_destroy].each do |callback_name|
-        klazz.define_callbacks callback_name
-
-        klazz.define_singleton_method("before_#{callback_name}") do |*args, &block|
-          set_callback(callback_name, :before, *args, &block)
-        end
-
-        klazz.define_singleton_method("around_#{callback_name}") do |*args, &block|
-          set_callback(callback_name, :around, *args, &block)
-        end
-
-        klazz.define_singleton_method("after_#{callback_name}") do |*args, &block|
-          set_callback(callback_name, :after, *args, &block)
-        end
-      end
     end
   end
 
@@ -241,6 +220,8 @@ end
 ActiveSupport.on_load(:active_record) do
   class ActiveRecord::Base
     def self.acts_as_paranoid(options={})
+      define_model_callbacks :restore, :real_destroy
+
       alias_method :really_destroyed?, :destroyed?
       alias_method :really_delete, :delete
       alias_method :destroy_without_paranoia, :destroy

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -71,6 +71,11 @@ module Paranoia
   end
   alias_method :destroy, :paranoia_destroy
 
+  def paranoia_destroy!
+    paranoia_destroy ||
+      raise(ActiveRecord::RecordNotDestroyed.new("Failed to destroy the record", self))
+  end
+
   def paranoia_delete
     raise ActiveRecord::ReadOnlyRecord, "#{self.class} is marked as readonly" if readonly?
     if persisted?


### PR DESCRIPTION
This allows users to be explicit about wanting to do a paranoia soft-delete instead of a normal hard-delete.