### PR TITLE
Version-related cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'sqlite3', platforms: [:ruby]
 
 platforms :jruby do
-  gem 'activerecord-jdbcsqlite3-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'rails-5'
+  gem 'activerecord-jdbcsqlite3-adapter'
 end
 
 platforms :rbx do

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ platforms :rbx do
   gem 'rubinius-developer_tools'
 end
 
-rails = ENV['RAILS'] || '~> 4.2.0'
+rails = ENV['RAILS'] || '~> 5.1.0'
 
 gem 'rails', rails
 

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -5,6 +5,10 @@ require 'paranoia'
 
 test_framework = defined?(MiniTest::Test) ? MiniTest::Test : MiniTest::Unit::TestCase
 
+if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks=)
+  ActiveRecord::Base.raise_in_transactional_callbacks = true
+end
+
 def connect!
   ActiveRecord::Base.establish_connection :adapter => 'sqlite3', database: ':memory:'
 end


### PR DESCRIPTION
* Default to rails 5.1
* A new version of `activerecord-jdbcsqlite3-adapter` is out, we don't need to use the git branch anymore.
* Avoid a warning on rails 4.2 by setting raise_in_transactional_callbacks