### PR TITLE
Ensure deleted_at, updated_at share the same value on delete

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -170,13 +170,17 @@ module Paranoia
   end
 
   def paranoia_destroy_attributes
+    timezoned_current_time = current_time_from_proper_timezone
+
     {
-      paranoia_column => current_time_from_proper_timezone
-    }.merge(timestamp_attributes_with_current_time)
+      paranoia_column => timezoned_current_time
+    }.merge(timestamp_attributes_with_current_time(timezoned_current_time))
   end
 
-  def timestamp_attributes_with_current_time
-    timestamp_attributes_for_update_in_model.each_with_object({}) { |attr,hash| hash[attr] = current_time_from_proper_timezone }
+  def timestamp_attributes_with_current_time(timezoned_current_time = nil)
+    timestamp_attributes_for_update_in_model.each_with_object({}) do |attr,hash| 
+      hash[attr] = timezoned_current_time || current_time_from_proper_timezone
+    end
   end
 
   # restore associated records that have been soft deleted when

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -842,6 +842,13 @@ class ParanoiaTest < test_framework
     assert paranoid_model.updated_at > 10.minutes.ago
   end
 
+  def test_updated_at_equals_deleted_at_to_acceptable_precision
+    paranoid_model = ParanoidModelWithTimestamp.create(:parent_model => ParentModel.create, :updated_at => 1.day.ago)
+    assert paranoid_model.updated_at < 10.minutes.ago
+    paranoid_model.destroy
+    assert_equal paranoid_model.updated_at.to_f, paranoid_model.deleted_at.to_f
+  end
+
   def test_updated_at_modification_on_restore
     parent1 = ParentModel.create
     pt1 = ParanoidModelWithTimestamp.create(:parent_model => parent1)


### PR DESCRIPTION
Previously, on a delete call, `current_time_from_proper_timezone` was called
twice, which yields two different values, leading Rails to save two distinct timestamps in 
the DB, if one compares at a sub-millisecond level. 

This leads to problems when decisions need to be made as to whether a record was updated
after it was deleted (whatever the reason for this might be). Under current arrangements, the response
will always be yes if the system prefers a higher precision, even if that is not the case. 

The solution is to memoize the value and share it between the two columns on save. This saves the values to an acceptable precision as dictated by Rails and the OS platform, but in any case it would cease to be a Paranoia problem. 