### PR TITLE
Improve method checks for cached associations

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -160,7 +160,7 @@ module Paranoia
   private
 
   def each_counter_cached_associations
-    !(defined?(@_disable_counter_cache) && @_disable_counter_cache) ? super : []
+    !(defined?(@_disable_counter_cache) && @_disable_counter_cache) && defined?(super) ? super : []
   end
 
   def paranoia_restore_attributes


### PR DESCRIPTION
There is an issue that I've encountered where there is no `super` for method `each_counter_cached_associations` for given class. This happens when doing `restore(recursive: true)` on corresponding object. 

Rails version:

```ruby
gem 'rails', '4.1.16'
```

Not sure what is the root cause of it, but this is easy fix for it. 