### PR TITLE
make sure callback is called on destroy

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -57,6 +57,7 @@ module Paranoia
       run_callbacks(:destroy) do
         @_disable_counter_cache = deleted?
         result = paranoia_delete
+        @_trigger_update_callback = result
         next result unless result && ActiveRecord::VERSION::STRING >= '4.2'
         each_counter_cached_associations do |association|
           foreign_key = association.reflection.foreign_key.to_sym

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -131,6 +131,14 @@ class ParanoiaTest < test_framework
     assert model.instance_variable_get(:@after_commit_callback_called)
   end
 
+  def test_destroy_behavior_for_conditional_models_callbacks
+    model = ConditionalCallbackModel.new
+    model.save
+    model.remove_called_variables     # clear called callback flags
+    model.destroy
+
+    assert model.instance_variable_get(:@after_commit_callback_called)
+  end
 
   def test_delete_behavior_for_plain_models_callbacks
     model = CallbackModel.new
@@ -1115,6 +1123,18 @@ class CallbackModel < ActiveRecord::Base
   after_commit        { |model| model.instance_variable_set :@after_commit_callback_called, true }
 
   validate            { |model| model.instance_variable_set :@validate_called, true }
+
+  def remove_called_variables
+    instance_variables.each {|name| (name.to_s.end_with?('_called')) ? remove_instance_variable(name) : nil}
+  end
+end
+
+class ConditionalCallbackModel < ActiveRecord::Base
+  self.table_name = 'callback_models'
+
+  acts_as_paranoid
+
+  after_commit   -> { instance_variable_set :@after_commit_callback_called, true }, on: :destroy
 
   def remove_called_variables
     instance_variables.each {|name| (name.to_s.end_with?('_called')) ? remove_instance_variable(name) : nil}


### PR DESCRIPTION
Inspired by how the destroy callback is ensured [in `acts_as_paranoid`](https://github.com/ActsAsParanoid/acts_as_paranoid/commit/f22f3a6f49b1a7ea0e3e2e0e3b1500ea69b317fe), we now flag the record to be triggering the update callback if the delete succeeded.

Altho while at it, it might be even better to actually set `@_trigger_destroy_callback` to `true`.

Probably need to add tests too.