### PR TITLE
Add a very soft deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+**Notice:** 
+
+`paranoia` has some surprising behaviour (like overriding ActiveRecord's `delete` and `destroy`) and is not recommended for new projects. See [`discard`'s README](https://github.com/jhawthorn/discard#why-not-paranoia-or-acts_as_paranoid) for more details.
+
+Paranoia will continue to accept bug fixes and support new versions of Rails but isn't accepting new features.
+
 # Paranoia
 
 Paranoia is a re-implementation of [acts\_as\_paranoid](http://github.com/ActsAsParanoid/acts_as_paranoid) for Rails 3/4/5, using much, much, much less code.


### PR DESCRIPTION
This isn't a change from how paranoia has been developed for the past few years, but makes it more explicit.

I hope the recommendation against new projects using paranoia isn't too controversial. I think anyone who has used this gem extensively has been surprised by it many times. This is just the nature of replacing ActiveRecord's behaviour. I believe paranoia does extremely well given that it has to do that.

A lot of developers will reach for paranoia or acts_as_paranoid because they're the first result they will find. However most users are just looking to hide or disable some records, and they would do much better to just toggle a flag rather than have paranoia override ActiveRecord's behaviour on their model.

I hope linking to discard here isn't inappropriate, I believe it's the best resource describe the caveats of paranoia as well as give a good example of how to soft-delete without needing paranoia or acts_as_paranoid.