### PR TITLE
Monkeypatch activerecord relations to work with rails >=5.2.0rc2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - RAILS='~> 4.2.0'
     - RAILS='~> 5.0.0'
     - RAILS='~> 5.1.0'
-    - RAILS='~> 5.2.0.beta2'
+    - RAILS='~> 5.2.0.rc2'
 
 matrix:
   allow_failures:
@@ -24,5 +24,5 @@ matrix:
       rvm: jruby-9.1.6.0
     - env: RAILS='~> 5.1.0'
       rvm: jruby-9.1.6.0
-    - env: RAILS='~> 5.2.0.beta2'
+    - env: RAILS='~> 5.2.0.rc2'
       rvm: jruby-9.1.6.0

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -1,4 +1,5 @@
 require 'active_record' unless defined? ActiveRecord
+require 'paranoia/active_record_patches'
 
 module Paranoia
   @@default_sentinel_value = nil

--- a/lib/paranoia/active_record_patches.rb
+++ b/lib/paranoia/active_record_patches.rb
@@ -1,0 +1,41 @@
+module HandleParanoiaDestroyedInBelongsToAssociation
+  def handle_dependency
+    return unless load_target
+
+    case options[:dependent]
+    when :destroy
+      target.destroy
+      if defined? target.deleted?
+        raise ActiveRecord::Rollback unless target.deleted?
+      else
+        raise ActiveRecord::Rollback unless target.destroyed?
+      end
+    else
+      target.send(options[:dependent])
+    end
+  end
+end
+
+module HandleParanoiaDestroyedInHasOneAssociation
+  def delete(method = options[:dependent])
+    if load_target
+      case method
+      when :delete
+        target.delete
+      when :destroy
+        target.destroyed_by_association = reflection
+        target.destroy
+        if defined? target.deleted?
+          throw(:abort) unless target.deleted?
+        else
+          throw(:abort) unless target.destroyed?
+        end
+      when :nullify
+        target.update_columns(reflection.foreign_key => nil) if target.persisted?
+      end
+    end
+  end
+end
+
+ActiveRecord::Associations::BelongsToAssociation.prepend HandleParanoiaDestroyedInBelongsToAssociation
+ActiveRecord::Associations::HasOneAssociation.prepend HandleParanoiaDestroyedInHasOneAssociation


### PR DESCRIPTION
Since this thing https://github.com/rails/rails/commit/b0fc04aa3af338d5a90608bf37248668d59fc881 got merged into rails, AR raises an exception and don't destroy record since relations seem not destroyed(because they're soft deleted instead of destroyed). 

We can monkeypatch ActiveRecord this way, but if someone has better solution, I will be glad.