### PR TITLE
Fix typo (`6.2.0` -> `5.2.0`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.4.1
 
-* [#435](https://github.com/rubysherpas/paranoia/pull/435) Monkeypatch activerecord relations to work with rails 6.2.0
+* [#435](https://github.com/rubysherpas/paranoia/pull/435) Monkeypatch activerecord relations to work with rails 5.2.0
 
   [Bartosz Bonisławski (@bbonislawski)](https://github.com/bbonislawski)
 


### PR DESCRIPTION
Maybe paranoia 2.4.1 supported Rails version is `5.2.0`.