### PR TITLE
Recursive restore with has_many/one through assocs

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -217,7 +217,12 @@ module Paranoia
 
       if association_data.nil? && association.macro.to_s == "has_one"
         association_class_name = association.klass.name
-        association_foreign_key = association.foreign_key
+
+        association_foreign_key = if association.options[:through].present?
+          association.klass.primary_key
+        else
+          association.foreign_key
+        end
 
         if association.type
           association_polymorphic_type = association.type
@@ -226,7 +231,7 @@ module Paranoia
           association_find_conditions = { association_foreign_key => self.id }
         end
 
-        association_class = association_class_name.constantize
+        association_class = association.klass
         if association_class.paranoid?
           association_class.only_deleted.where(association_find_conditions).first
             .try!(:restore, recursive: true, :recovery_window_range => recovery_window_range)

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -49,7 +49,11 @@ def setup!
     'active_column_model_with_uniqueness_validations' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN',
     'paranoid_model_with_belongs_to_active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN, active_column_model_with_has_many_relationship_id INTEGER',
     'active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN',
-    'without_default_scope_models' => 'deleted_at DATETIME'
+    'without_default_scope_models' => 'deleted_at DATETIME',
+    'paranoid_has_through_restore_parents' => 'deleted_at DATETIME',
+    'empty_paranoid_models' => 'deleted_at DATETIME',
+    'paranoid_has_one_throughs' => 'paranoid_has_through_restore_parent_id INTEGER NOT NULL, empty_paranoid_model_id INTEGER NOT NULL, deleted_at DATETIME',
+    'paranoid_has_many_throughs' => 'paranoid_has_through_restore_parent_id INTEGER NOT NULL, empty_paranoid_model_id INTEGER NOT NULL, deleted_at DATETIME',
   }.each do |table_name, columns_as_sql_string|
     ActiveRecord::Base.connection.execute "CREATE TABLE #{table_name} (id INTEGER NOT NULL PRIMARY KEY, #{columns_as_sql_string})"
   end
@@ -1055,6 +1059,40 @@ class ParanoiaTest < test_framework
     assert_equal 1, polymorphic.class.count
   end
 
+  def test_recursive_restore_with_has_through_associations
+    parent = ParanoidHasThroughRestoreParent.create
+    one = EmptyParanoidModel.create
+    ParanoidHasOneThrough.create(
+      :paranoid_has_through_restore_parent => parent,
+      :empty_paranoid_model => one,
+    )
+    many = Array.new(3) do
+      many = EmptyParanoidModel.create
+      ParanoidHasManyThrough.create(
+        :paranoid_has_through_restore_parent => parent,
+        :empty_paranoid_model => many,
+      )
+
+      many
+    end
+
+    assert_equal true, parent.empty_paranoid_model.present?
+    assert_equal 3, parent.empty_paranoid_models.count
+
+    parent.destroy
+
+    assert_equal true, parent.empty_paranoid_model.reload.deleted?
+    assert_equal 0, parent.empty_paranoid_models.count
+
+    parent = ParanoidHasThroughRestoreParent.with_deleted.first
+    parent.restore(recursive: true)
+
+    assert_equal false, parent.empty_paranoid_model.deleted?
+    assert_equal one, parent.empty_paranoid_model
+    assert_equal 3, parent.empty_paranoid_models.count
+    assert_equal many, parent.empty_paranoid_models
+  end
+
   # Ensure that we're checking parent_type when restoring
   def test_missing_restore_recursive_on_polymorphic_has_one_association
     parent = ParentModel.create
@@ -1554,4 +1592,30 @@ module Namespaced
     acts_as_paranoid
     belongs_to :paranoid_has_one
   end
+end
+
+class ParanoidHasThroughRestoreParent < ActiveRecord::Base
+  acts_as_paranoid
+
+  has_one :paranoid_has_one_through, dependent: :destroy
+  has_one :empty_paranoid_model, through: :paranoid_has_one_through, dependent: :destroy
+
+  has_many :paranoid_has_many_throughs, dependent: :destroy
+  has_many :empty_paranoid_models, through: :paranoid_has_many_throughs, dependent: :destroy
+end
+
+class EmptyParanoidModel < ActiveRecord::Base
+  acts_as_paranoid
+end
+
+class ParanoidHasOneThrough < ActiveRecord::Base
+  acts_as_paranoid
+  belongs_to :paranoid_has_through_restore_parent
+  belongs_to :empty_paranoid_model, dependent: :destroy
+end
+
+class ParanoidHasManyThrough < ActiveRecord::Base
+  acts_as_paranoid
+  belongs_to :paranoid_has_through_restore_parent
+  belongs_to :empty_paranoid_model, dependent: :destroy
 end


### PR DESCRIPTION
The query to find deleted has_many or has_one through associations
was being generated incorrectly because of specifying the wrong
foreign key for the table. This change uses the has_one/has_many
model's primary key as the foreign key.

Without the associated code change, the given test generates the following
error:

```
Error:
ParanoiaTest#test_recursive_restore_with_has_through_associations:
ActiveRecord::StatementInvalid: SQLite3::SQLException: no such column: empty_paranoid_models.empty_paranoid_model_id: SELECT  "empty_paranoid_models".* FROM "empty_paranoid_models" WHERE "empty_paranoid_models"."deleted_at" IS NOT NULL AND "empty_paranoid_models"."empty_paranoid_model_id" = ? ORDER BY "empty_paranoid_models"."id" ASC LIMIT ?
    /home/emil/.rvm/gems/ruby-2.4.0/gems/sqlite3-1.3.13/lib/sqlite3/database.rb:91:in `initialize'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/sqlite3-1.3.13/lib/sqlite3/database.rb:91:in `new'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/sqlite3-1.3.13/lib/sqlite3/database.rb:91:in `prepare'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/sqlite3_adapter.rb:228:in `block (2 levels) in exec_query'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activesupport-5.2.0/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activesupport-5.2.0/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activesupport-5.2.0/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/sqlite3_adapter.rb:213:in `block in exec_query'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract_adapter.rb:579:in `block (2 levels) in log'
    /home/emil/.rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract_adapter.rb:578:in `block in log'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activesupport-5.2.0/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract_adapter.rb:569:in `log'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/sqlite3_adapter.rb:212:in `exec_query'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/database_statements.rb:469:in `select_prepared'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/database_statements.rb:55:in `select_all'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/query_cache.rb:101:in `select_all'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/querying.rb:41:in `find_by_sql'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/relation.rb:554:in `block in exec_queries'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/relation.rb:578:in `skip_query_cache_if_necessary'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/relation.rb:542:in `exec_queries'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/relation.rb:414:in `load'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/relation.rb:200:in `records'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/relation.rb:195:in `to_ary'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/relation/finder_methods.rb:530:in `find_nth_with_limit'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/relation/finder_methods.rb:515:in `find_nth'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/relation/finder_methods.rb:125:in `first'
    /home/emil/src/paranoia/lib/paranoia.rb:224:in `block in restore_associated_records'
    /home/emil/src/paranoia/lib/paranoia.rb:193:in `each'
    /home/emil/src/paranoia/lib/paranoia.rb:193:in `restore_associated_records'
    /home/emil/src/paranoia/lib/paranoia.rb:115:in `block (2 levels) in restore!'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activesupport-5.2.0/lib/active_support/callbacks.rb:132:in `run_callbacks'
    /home/emil/src/paranoia/lib/paranoia.rb:99:in `block in restore!'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/database_statements.rb:254:in `block in transaction'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/transaction.rb:230:in `block in within_new_transaction'
    /home/emil/.rvm/rubies/ruby-2.4.0/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/transaction.rb:227:in `within_new_transaction'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/connection_adapters/abstract/database_statements.rb:254:in `transaction'
    /home/emil/.rvm/gems/ruby-2.4.0/gems/activerecord-5.2.0/lib/active_record/transactions.rb:212:in `transaction'
    /home/emil/src/paranoia/lib/paranoia.rb:98:in `restore!'
    test/paranoia_test.rb:967:in `test_recursive_restore_with_has_through_associations'
```