### PR TITLE
Fix `SystemStackError` when paranoid models have a circular `dependent: :destroy`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: ruby
-before_install: gem update --system
+before_install:
+   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+   - gem install bundler -v '< 2'
 cache: bundler
 rvm:
   - 2.2

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -1,9 +1,6 @@
 require 'active_record' unless defined? ActiveRecord
 
-if [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR] == [5, 2] ||
-   ActiveRecord::VERSION::MAJOR > 5
-  require 'paranoia/active_record_5_2'
-end
+require 'paranoia/active_record_5_2'
 
 module Paranoia
   @@default_sentinel_value = nil

--- a/lib/paranoia/active_record_5_2.rb
+++ b/lib/paranoia/active_record_5_2.rb
@@ -4,6 +4,9 @@ module HandleParanoiaDestroyedInBelongsToAssociation
 
     case options[:dependent]
     when :destroy
+      @_destroy_callback_already_called ||= false
+      return if @_destroy_callback_already_called
+      @_destroy_callback_already_called = true
       target.destroy
       if target.respond_to?(:paranoia_destroyed?)
         raise ActiveRecord::Rollback unless target.paranoia_destroyed?
@@ -23,7 +26,10 @@ module HandleParanoiaDestroyedInHasOneAssociation
       when :delete
         target.delete
       when :destroy
+        @_destroy_callback_already_called ||= false
+        return if @_destroy_callback_already_called
         target.destroyed_by_association = reflection
+        @_destroy_callback_already_called = true
         target.destroy
         if target.respond_to?(:paranoia_destroyed?)
           throw(:abort) unless target.paranoia_destroyed?


### PR DESCRIPTION
- Previously, paranoid models with a circular `dependent: :destroy` would recursively try to delete eachother, causing a `stack level too deep` error
- Add a variable to check if the destroy callback has already been called for that model
- Similar to fix rails/rails#18548