### PR TITLE
Update README docs for paranoia_destroy_attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ class Client < ActiveRecord::Base
   def paranoia_destroy_attributes
     {
       deleted_at: current_time_from_proper_timezone,
-      active: nil
+      active: false
     }
   end
 end


### PR DESCRIPTION
Since active is a boolean column, it would be better to send `false` than `nil`