### PR TITLE
Use merge! instead of merge

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -170,13 +170,13 @@ module Paranoia
   def paranoia_restore_attributes
     {
       paranoia_column => paranoia_sentinel_value
-    }.merge(timestamp_attributes_with_current_time)
+    }.merge!(timestamp_attributes_with_current_time)
   end
 
   def paranoia_destroy_attributes
     {
       paranoia_column => current_time_from_proper_timezone
-    }.merge(timestamp_attributes_with_current_time)
+    }.merge!(timestamp_attributes_with_current_time)
   end
 
   def timestamp_attributes_with_current_time


### PR DESCRIPTION
The patch speeds up and reduce memory allocation of `paranoia_restore_attributes` and `paranoia_destroy_attributes`.

```ruby
require 'benchmark/ips'
require 'benchmark/memory'

[:ips, :memory].each do |type|
  Benchmark.public_send(type) do |x|
    x.report('merge') { { a: 1, b: 2, c: 3 }.merge d: 4, e: 5 }
    x.report('merge!') { { a: 1, b: 2, c: 3 }.merge! d: 4, e: 5 }

    x.compare!
  end
end

Warming up --------------------------------------
               merge    42.722k i/100ms
              merge!    67.071k i/100ms
Calculating -------------------------------------
               merge    463.139k (± 3.4%) i/s -      2.350M in   5.079936s
              merge!    793.106k (± 2.7%) i/s -      4.024M in   5.077932s

Comparison:
              merge!:   793106.4 i/s
               merge:   463138.6 i/s - 1.71x  slower

Calculating -------------------------------------
               merge   672.000  memsize (     0.000  retained)
                         3.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
              merge!   480.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
              merge!:        480 allocated
               merge:        672 allocated - 1.40x more
```