### PR TITLE
Bump ActiveRecord dependency

### DIFF
--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'activerecord', '>= 4.0', '< 5.3'
+  s.add_dependency 'activerecord', '>= 4.0', '< 6.1'
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake"


### PR DESCRIPTION
This allows Rails 6.0.0.beta1 to install Paranoia.

I followed the existing convention of existing minor+1 (e.g. Rails 5.2 was released but paranoia allowed '< 5.3') even though the beta1 could be installed if I set it to '< 6.0'.

With out this change Bundler was falling back to Paranoia 1.2 when upgrading to Rails 6. Then everything blew up 💥 😅 

So far everything seems to be working well with 6. I will continue to test and am happy to submit patches if I find anything.

If you'd prefer to keep this on a `rails6` branch let me know I can update the PR.