### PR TITLE
Support ActiveRecord 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - RAILS='~> 5.0.0'
     - RAILS='~> 5.1.0'
     - RAILS='~> 5.2.0'
+    - RAILS='master'
 
 matrix:
   allow_failures:
@@ -26,3 +27,10 @@ matrix:
       rvm: jruby-9.1.6.0
     - env: RAILS='~> 5.2.0'
       rvm: jruby-9.1.6.0
+    - env: RAILS='master'
+      rvm: jruby-9.1.6.0
+  exclude:
+    - rvm: 2.2
+      env: RAILS='master'
+    - rvm: 2.3.5
+      env: RAILS='master'

--- a/Gemfile
+++ b/Gemfile
@@ -7,14 +7,18 @@ platforms :jruby do
 end
 
 platforms :rbx do
+  gem 'rubinius-developer_tools'
   gem 'rubysl', '~> 2.0'
   gem 'rubysl-test-unit'
-  gem 'rubinius-developer_tools'
 end
 
 rails = ENV['RAILS'] || '~> 5.2.0'
 
-gem 'rails', rails
+if rails == 'master'
+  gem 'rails', github: 'rails/rails'
+else
+  gem 'rails', rails
+end
 
 # Specify your gem's dependencies in paranoia.gemspec
 gemspec

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -1,6 +1,7 @@
 require 'active_record' unless defined? ActiveRecord
 
-if [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR] == [5, 2]
+if [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR] == [5, 2] ||
+   ActiveRecord::VERSION::MAJOR > 5
   require 'paranoia/active_record_5_2'
 end
 
@@ -305,7 +306,7 @@ module ActiveRecord
     class UniquenessValidator < ActiveModel::EachValidator
       prepend UniquenessParanoiaValidator
     end
-    
+
     class AssociationNotSoftDestroyedValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
         # if association is soft destroyed, add an error

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'activerecord', '>= 4.0'
+  s.add_dependency 'activerecord', '>= 4.0', '< 6.2'
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake"

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'activerecord', '>= 4.0', '< 5.3'
+  s.add_dependency 'activerecord', '>= 4.0'
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake"


### PR DESCRIPTION
This pulls in @iggant's change from #456, but adds back in the upper version constraint on activerecord.