### PR TITLE
.really_destroy! should not destroy has_many :through records

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -141,7 +141,8 @@ module Paranoia
       run_callbacks(:real_destroy) do
         @_disable_counter_cache = paranoia_destroyed?
         dependent_reflections = self.class.reflections.select do |name, reflection|
-          reflection.options[:dependent] == :destroy
+          reflection.options[:dependent] == :destroy &&
+            reflection.options[:through].blank?
         end
         if dependent_reflections.any?
           dependent_reflections.each do |name, reflection|


### PR DESCRIPTION
Despite of counter intuitive, Rails API states that `has_many :through` records must not be destroyed, but their associations https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-has_many

> If using with the `:through` option, the association on the join model must be a `belongs_to`, and the records which get deleted are the join records, rather than the associated records.

`paranoia` should have the same behavior 

Fixes #466