### PR TITLE
Allow paranoia gem installation in Rails 6 codebase

### DIFF
--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'activerecord', '>= 4.0', '< 5.3'
+  s.add_dependency 'activerecord', '>= 4.0', '< 6.1'
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake"


### PR DESCRIPTION
Bump activerecord dependency to `< 6.1`