### PR TITLE
Add support for Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - RAILS='~> 5.0.0'
     - RAILS='~> 5.1.0'
     - RAILS='~> 5.2.0'
+    - RAILS='~> 6.0.0.beta3'
 
 matrix:
   allow_failures:
@@ -26,4 +27,12 @@ matrix:
     - env: RAILS='~> 5.1.0'
       rvm: jruby-9.1.6.0
     - env: RAILS='~> 5.2.0'
+      rvm: jruby-9.1.6.0
+    - env: RAILS='~> 6.0.0.beta3'
+      rvm: 2.2
+    - env: RAILS='~> 6.0.0.beta3'
+      rvm: 2.3.8
+    - env: RAILS='~> 6.0.0.beta3'
+      rvm: 2.4.5
+    - env: RAILS='~> 6.0.0.beta3'
       rvm: jruby-9.1.6.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'sqlite3', platforms: [:ruby]
+gem 'sqlite3', '~> 1.3.6', platforms: [:ruby]
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -1,6 +1,6 @@
 require 'active_record' unless defined? ActiveRecord
 
-if [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR] == [5, 2]
+if ActiveRecord::VERSION::STRING >= "5.2"
   require 'paranoia/active_record_5_2'
 end
 

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'activerecord', '>= 4.0', '< 5.3'
+  s.add_dependency 'activerecord', '>= 4.0', '< 6.1'
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake"


### PR DESCRIPTION
Rails 6 is currently in its third beta [1] and I discovered a couple of issues with this gem whilst attempting to upgrade the application I have been working on.

It looks like we can reuse the existing Rails 5.2 association mixins (based on manual testing and running the build locally against Rails `6.0.0.beta3`).

As part of this branch I have also configured travis to run against Rails 6.0.0.beta3.

[1] https://weblog.rubyonrails.org/2019/3/13/Rails-4-2-5-1-5-1-6-2-have-been-released/