### PR TITLE
Use paranoia_destroyed? instead of deleted?

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -60,7 +60,7 @@ module Paranoia
   def paranoia_destroy
     transaction do
       run_callbacks(:destroy) do
-        @_disable_counter_cache = deleted?
+        @_disable_counter_cache = paranoia_destroyed?
         result = paranoia_delete
         next result unless result && ActiveRecord::VERSION::STRING >= '4.2'
         each_counter_cached_associations do |association|


### PR DESCRIPTION
https://github.com/rubysherpas/paranoia/commit/2b0db84f38a0e436abbb129c770b0dac9275a802 introduced `record.paranoia_destroyed?`
https://github.com/rubysherpas/paranoia/pull/390 introduced usage of `record.deleted?` to `record.paranoia_destroy`


A project I work on has a database column named `deleted`.  The usage of the `deleted?` method by `paranoia_destroy` clashes with that column, preventing us to update to a newer version of this gem.
Using `paranoia_destroyed?` avoids that clash.

Since `deleted?` is literally an alias of `paranoia_destroyed?`, I cannot imagine there being downsides to this change. 



