### PR TITLE
gets deletion time from paranoia_column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # paranoia Changelog
 
+## 2.5.1
+
+* [#481](https://github.com/rubysherpas/paranoia/pull/481) Replaces hard coded `deleted_at` with `paranoia_column`.
+
+ [Hassanin Ahmed](https://github.com/sas1ni69)
+
 ## 2.5.0
 
  * [#516](https://github.com/rubysherpas/paranoia/pull/516) Add support for ActiveRecord 7.0, drop support for EOL Ruby < 2.5 and Rails < 5.1
@@ -9,7 +15,6 @@
  * [#515](https://github.com/rubysherpas/paranoia/pull/515) Switch from Travis CI to GitHub Actions
 
    [Shinichi Maeshima](https://github.com/willnet)
-
 
 ## 2.4.3
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -129,16 +129,16 @@ module Paranoia
   def get_recovery_window_range(opts)
     return opts[:recovery_window_range] if opts[:recovery_window_range]
     return unless opts[:recovery_window]
-    (deleted_at - opts[:recovery_window]..deleted_at + opts[:recovery_window])
+    (deletion_time - opts[:recovery_window]..deletion_time + opts[:recovery_window])
   end
 
   def within_recovery_window?(recovery_window_range)
     return true unless recovery_window_range
-    recovery_window_range.cover?(deleted_at)
+    recovery_window_range.cover?(deletion_time)
   end
 
   def paranoia_destroyed?
-    send(paranoia_column) != paranoia_sentinel_value
+    deletion_time != paranoia_sentinel_value
   end
   alias :deleted? :paranoia_destroyed?
 
@@ -292,6 +292,10 @@ ActiveSupport.on_load(:active_record) do
 
     def paranoia_sentinel_value
       self.class.paranoia_sentinel_value
+    end
+
+    def deletion_time
+      send(paranoia_column)
     end
   end
 end

--- a/lib/paranoia/version.rb
+++ b/lib/paranoia/version.rb
@@ -1,3 +1,3 @@
 module Paranoia
-  VERSION = '2.5.0'.freeze
+  VERSION = '2.5.1'.freeze
 end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -245,6 +245,22 @@ class ParanoiaTest < test_framework
     assert_equal 1, model.class.deleted.count
   end
 
+  def test_destroy_behavior_for_custom_column_models_with_recovery_options
+    model = CustomColumnModel.new
+    model.save!
+
+    assert_nil model.destroyed_at
+
+    model.destroy
+
+    assert_equal false, model.destroyed_at.nil?
+    assert model.paranoia_destroyed?
+
+    model.restore!(recovery_window: 2.minutes)
+
+    assert_equal 1, model.class.count
+  end
+
   def test_default_sentinel_value
     assert_nil ParanoidModel.paranoia_sentinel_value
   end


### PR DESCRIPTION
Using the `recovery_window` option with a custom column name raises an exception since the `deleted_at` value is hard coded.