### PR TITLE
Fix after_commit for Rails 6

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -69,7 +69,7 @@ module Paranoia
           next unless send(association.reflection.name)
           association.decrement_counters
         end
-        @_trigger_update_callback = true
+        @_trigger_destroy_callback = true
         @_disable_counter_cache = false
         result
       end
@@ -80,6 +80,10 @@ module Paranoia
   def paranoia_destroy!
     paranoia_destroy ||
       raise(ActiveRecord::RecordNotDestroyed.new("Failed to destroy the record", self))
+  end
+
+  def trigger_transactional_callbacks?
+    super || @_trigger_destroy_callback && paranoia_destroyed?
   end
 
   def paranoia_delete

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -69,6 +69,7 @@ module Paranoia
           next unless send(association.reflection.name)
           association.decrement_counters
         end
+        @_trigger_update_callback = true
         @_disable_counter_cache = false
         result
       end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -131,6 +131,21 @@ class ParanoiaTest < test_framework
     assert model.instance_variable_get(:@after_commit_callback_called)
   end
 
+  def test_destroy_behavior_for_freshly_loaded_plain_models_callbacks
+    model = CallbackModel.new
+    model.save
+
+    model = CallbackModel.find(model.id)
+    model.destroy
+
+    assert_nil model.instance_variable_get(:@update_callback_called)
+    assert_nil model.instance_variable_get(:@save_callback_called)
+    assert_nil model.instance_variable_get(:@validate_called)
+
+    assert model.instance_variable_get(:@destroy_callback_called)
+    assert model.instance_variable_get(:@after_destroy_callback_called)
+    assert model.instance_variable_get(:@after_commit_callback_called)
+  end
 
   def test_delete_behavior_for_plain_models_callbacks
     model = CallbackModel.new


### PR DESCRIPTION
Trigger after_commit on destroy to work with rails 6

This addresses https://github.com/rubysherpas/paranoia/issues/478