### PR TITLE
Warn if acts_as_paranoid is called more than once on the same model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # paranoia Changelog
 
+## 2.5.2
+
+* [#492](https://github.com/rubysherpas/paranoia/pull/492) Warn if acts_as_paranoid is called more than once on the same model
+
+ [Ignatius Reza](https://github.com/ignatiusreza)
+
 ## 2.5.1
 
 * [#481](https://github.com/rubysherpas/paranoia/pull/481) Replaces hard coded `deleted_at` with `paranoia_column`.

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -242,6 +242,12 @@ end
 ActiveSupport.on_load(:active_record) do
   class ActiveRecord::Base
     def self.acts_as_paranoid(options={})
+      if included_modules.include?(Paranoia)
+        puts "[WARN] #{self.name} is calling acts_as_paranoid more than once!"
+
+        return
+      end
+
       define_model_callbacks :restore, :real_destroy
 
       alias_method :really_destroyed?, :destroyed?

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -83,6 +83,17 @@ class ParanoiaTest < test_framework
     assert_equal true, ParanoidModel.paranoid?
   end
 
+  def test_doubly_paranoid_model_class_is_warned
+    assert_output(/DoublyParanoidModel is calling acts_as_paranoid more than once!/) do
+      DoublyParanoidModel.acts_as_paranoid
+    end
+
+    refute_equal(
+      DoublyParanoidModel.instance_method(:destroy).source_location,
+      DoublyParanoidModel.instance_method(:destroy_without_paranoia).source_location
+    )
+  end
+
   def test_plain_models_are_not_paranoid
     assert_equal false, PlainModel.new.paranoid?
   end
@@ -1096,6 +1107,11 @@ end
 
 class ParanoidModel < ActiveRecord::Base
   belongs_to :parent_model
+  acts_as_paranoid
+end
+
+class DoublyParanoidModel < ActiveRecord::Base
+  self.table_name = 'plain_models'
   acts_as_paranoid
 end
 


### PR DESCRIPTION
which will breaks the method aliasing of `#destroy` and makes them lost
access to the original one defined by ActiveRecord

fix #489