### PR TITLE
Fixes travis build*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,37 +3,29 @@ language: ruby
 before_install: gem update --system
 cache: bundler
 rvm:
-  - 2.2
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.3
-  - jruby-9.1.6.0
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 
 env:
   matrix:
-    - RAILS='~> 4.2.0' SQLITE_VERSION='~> 1.3.6'
     - RAILS='~> 5.0.0' SQLITE_VERSION='~> 1.3.6'
     - RAILS='~> 5.1.0'
     - RAILS='~> 5.2.0'
+    - RAILS='~> 6.0.0'
     - RAILS='master'
 
 matrix:
-  allow_failures:
-    - env: RAILS='~> 4.2.0' SQLITE_VERSION='~> 1.3.6'
-      rvm: jruby-9.1.6.0
-    - env: RAILS='~> 5.0.0' SQLITE_VERSION='~> 1.3.6'
-      rvm: jruby-9.1.6.0
-    - env: RAILS='~> 5.1.0'
-      rvm: jruby-9.1.6.0
-    - env: RAILS='~> 5.2.0'
-      rvm: jruby-9.1.6.0
-    - env: RAILS='master'
-      rvm: jruby-9.1.6.0
   exclude:
-    - rvm: 2.2
-      env: RAILS='master'
+    # Rails 6 requires ruby >= 2.5
+    - rvm: 2.3.8
+      env: RAILS='~> 6.0.0'
     - rvm: 2.3.8
       env: RAILS='master'
-    - rvm: 2.4.5
+    - rvm: 2.4.10
+      env: RAILS='~> 6.0.0'
+    - rvm: 2.4.10
       env: RAILS='master'
+

--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,4 @@ end
 
 # Specify your gem's dependencies in paranoia.gemspec
 gemspec
+


### PR DESCRIPTION
Update rubies to latest patches
Adds 2.7
Drops Rails < 5
Adds Rails 6
Drops jruby (seems they have been failing for [quite some time anyways](https://travis-ci.com/github/rubysherpas/paranoia/branches)...)
