### PR TITLE
Bump activerecord dependency for Rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
     - RAILS='~> 5.0.0' SQLITE_VERSION='~> 1.3.6'
     - RAILS='~> 5.1.0'
     - RAILS='~> 5.2.0'
+    - RAILS='~> 6.1.0'
     - RAILS='master'
 
 matrix:
@@ -31,8 +32,14 @@ matrix:
       rvm: jruby-9.2.8.0
     - env: RAILS='master'
       rvm: jruby-9.2.8.0
+    - env: RAILS='~> 6.1.0'
+      rvm: jruby-9.2.8.0
   exclude:
     - rvm: 2.3.8
       env: RAILS='master'
     - rvm: 2.4.5
       env: RAILS='master'
+    - rvm: 2.3.8
+      env: RAILS='~> 6.1.0'
+    - rvm: 2.4.5
+      env: RAILS='~> 6.1.0'

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -316,7 +316,7 @@ module ActiveRecord
       def validate_each(record, attribute, value)
         # if association is soft destroyed, add an error
         if value.present? && value.paranoia_destroyed?
-          record.errors[attribute] << 'has been soft-deleted'
+          record.errors.add(attribute, 'has been soft-deleted')
         end
       end
     end

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'activerecord', '>= 4.0', '< 6.1'
+  s.add_dependency 'activerecord', '>= 4.0', '< 6.2'
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake"


### PR DESCRIPTION
Allows using paranoia with Rails 6.1. This is a follow up of https://github.com/rubysherpas/paranoia/pull/501 and bumps the dependency in the gemspec, adds Rails 6.1 to the build matrix, and fixes a deprecation message.

@walski wrote in https://github.com/rubysherpas/paranoia/pull/501#issuecomment-742757751:

> I'm happy to close this PR in favor of a new one from @joergschiller