### PR TITLE
Add changelog for v2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # paranoia Changelog
 
+## 2.4.3
+
+* [#503](https://github.com/rubysherpas/paranoia/pull/503) Bump activerecord dependency for Rails 6.1
+
+  [Jörg Schiller](https://github.com/joergschiller)
+
+* [#483](https://github.com/rubysherpas/paranoia/pull/483) Update JRuby version to 9.2.8.0 + remove EOL Ruby 2.2 
+
+  [Uwe Kubosch](https://github.com/donv)
+
+* [#482](https://github.com/rubysherpas/paranoia/pull/482) Fix after_commit for Rails 6
+
+  [Ashwin Hegde](https://github.com/hashwin)
+
 ## 2.4.2
 
 * [#470](https://github.com/rubysherpas/paranoia/pull/470) Add support for ActiveRecord 6.0


### PR DESCRIPTION
This PR adds missing changelog for [v2.4.3](https://rubygems.org/gems/paranoia/versions/2.4.3).
I picked these changes from https://github.com/rubysherpas/paranoia/compare/v2.4.2...03d0779327b1604befd6dd36001cd8fcb908bff9.

BTW, It seems a release tag is missing.