### PR TITLE
Update supported Rails version in paranoia.gemspec

### DIFF
--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.summary     = "Paranoia is a re-implementation of acts_as_paranoid for Rails 3, 4, and 5, using much, much, much less code."
   s.description = <<-DSC
-    Paranoia is a re-implementation of acts_as_paranoid for Rails 3, 4, and 5,
+    Paranoia is a re-implementation of acts_as_paranoid for Rails 4, 5, and 6,
     using much, much, much less code. You would use either plugin / gem if you
     wished that when you called destroy on an Active Record object that it
     didn't actually destroy it, but just "hid" the record. Paranoia does this


### PR DESCRIPTION
Supported versions are described in the following:
https://github.com/rubysherpas/paranoia/blob/03d0779327b1604befd6dd36001cd8fcb908bff9/paranoia.gemspec#L27