### PR TITLE
[Mysql] small update to quote table names. Mysql 8 has keywords that…

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -40,7 +40,7 @@ module Paranoia
       # these will not match != sentinel value because "NULL != value" is
       # NULL under the sql standard
       # Scoping with the table_name is mandatory to avoid ambiguous errors when joining tables.
-      scoped_quoted_paranoia_column = "#{self.table_name}.#{connection.quote_column_name(paranoia_column)}"
+      scoped_quoted_paranoia_column = "#{connection.quote_table_name(self.table_name)}.#{connection.quote_column_name(paranoia_column)}"
       with_deleted.where("#{scoped_quoted_paranoia_column} IS NULL OR #{scoped_quoted_paranoia_column} != ?", paranoia_sentinel_value)
     end
     alias_method :deleted, :only_deleted


### PR DESCRIPTION
… might match table names which cause an exception when selecting with the deleted/deleted at columns.

To reproduce the issue:
We have Rails model Group with its table name as 'groups'. It is related to another model/table Content/contents

We use mysql 8
Rails 6 (latest)
When we try to restore a record:
```
Content.only_deleted.last.restore(recursive: true, recovery_window: 2.minutes)
```

We get this error:
```
mnt/f0ef7dec-1a57-4dbb-b044-478d728be42f/.gem/ruby/3.0.2/gems/mysql2-0.5.3/lib/mysql2/client.rb:131:in `_query': Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'groups.`deleted` IS NULL OR groups.`deleted` != FALSE)' at line 1 (ActiveRecord::StatementInvalid)
/mnt/f0ef7dec-1a57-4dbb-b044-478d728be42f/.gem/ruby/3.0.2/gems/mysql2-0.5.3/lib/mysql2/client.rb:131:in `_query': You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'groups.`deleted` IS NULL OR groups.`deleted` != FALSE)' at line 1 (Mysql2::Error)
```

The issue with mysql 8 is 'groups' is now a reserved word. This is clashing with our table name. To overcome this the table name needs to quoted just like is done with the column name.

We are actually just expecting the record to be restored with its associations. 

So this:
```
groups.`deleted` IS NULL OR groups.`deleted` != FALSE) should be this `groups`.`deleted` IS NULL OR `groups`.`deleted`
```

Here is a gist of the Gemfile.lock: https://gist.github.com/Kyle-Ferrara/593116e6af8170a2d99598946d459dec

There might be a better solution to this issue. This is what I could see. Feel free to take it or leave it lol. 
I hope this will help guys using mysql 8.