### PR TITLE
Fix create callback called on destroy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ platforms :rbx do
   gem 'rubysl-test-unit'
 end
 
-rails = ENV['RAILS'] || '~> 5.2.0'
+rails = ENV['RAILS'] || '~> 6.0.4'
 
 if rails == 'master'
   gem 'rails', github: 'rails/rails'

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -58,7 +58,7 @@ module Paranoia
   end
 
   def paranoia_destroy
-    transaction do
+    with_transaction_returning_status do
       run_callbacks(:destroy) do
         @_disable_counter_cache = deleted?
         result = paranoia_delete
@@ -143,7 +143,7 @@ module Paranoia
   alias :deleted? :paranoia_destroyed?
 
   def really_destroy!
-    transaction do
+    with_transaction_returning_status do
       run_callbacks(:real_destroy) do
         @_disable_counter_cache = paranoia_destroyed?
         dependent_reflections = self.class.reflections.select do |name, reflection|


### PR DESCRIPTION
We were running into a weird bug in one of our projects while migrating from Rails 5.2 to Rails 6.0. It seems to be due to Rails using `#with_transaction_returning_status` when persisting models which takes care of setting the recently-added ivar `@_new_record_before_last_commit`. Paranoia overrides ActiveRecord's `#destroy` with `#paranoia_destroy` which unfortunately only uses `#transaction`, so when checking for which callbacks should be run, it was seeing a stale value of `@_new_record_before_last_commit`, therefore causing `after_create_commit` hooks to be called again.