### PR TITLE
[DON'T MERGE] Add failing tests for association with abort on destroy

### DIFF
--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -31,6 +31,7 @@ def setup!
     'plain_models' => 'deleted_at DATETIME',
     'callback_models' => 'deleted_at DATETIME',
     'fail_callback_models' => 'deleted_at DATETIME',
+    'association_with_abort_models' => 'deleted_at DATETIME',
     'related_models' => 'parent_model_id INTEGER, parent_model_with_counter_cache_column_id INTEGER, deleted_at DATETIME',
     'asplode_models' => 'parent_model_id INTEGER, deleted_at DATETIME',
     'employers' => 'name VARCHAR(32), deleted_at DATETIME',
@@ -129,6 +130,35 @@ class ParanoiaTest < test_framework
     assert model.instance_variable_get(:@destroy_callback_called)
     assert model.instance_variable_get(:@after_destroy_callback_called)
     assert model.instance_variable_get(:@after_commit_callback_called)
+  end
+
+  def test_destroy_behavior_for_association_with_abort
+    model = AssociationWithAbortModel.new
+    model.related_models.build
+    model.save
+
+    assert_equal model.reload.related_models.count, 1
+
+    model = AssociationWithAbortModel.find(model.id)
+    return_value = model.destroy
+
+    assert_equal return_value, false
+    assert_equal model.reload.related_models.count, 1
+  end
+
+  def test_destroy_bang_behavior_for_association_with_abort
+    model = AssociationWithAbortModel.new
+    model.related_models.build
+    model.save
+
+    assert_equal model.reload.related_models.count, 1
+
+    model = AssociationWithAbortModel.find(model.id)
+    assert_raises ActiveRecord::RecordNotDestroyed do
+      model.destroy!
+    end
+
+    assert_equal model.reload.related_models.count, 1
   end
 
   def test_destroy_behavior_for_freshly_loaded_plain_models_callbacks
@@ -1134,6 +1164,18 @@ class CallbackModel < ActiveRecord::Base
   def remove_called_variables
     instance_variables.each {|name| (name.to_s.end_with?('_called')) ? remove_instance_variable(name) : nil}
   end
+end
+
+class AssociationWithAbortModel < ActiveRecord::Base
+  acts_as_paranoid
+  has_many :related_models, class_name: 'RelatedModel', foreign_key: :parent_model_id, dependent: :destroy
+  before_destroy { |_|
+    if ActiveRecord::VERSION::MAJOR < 5
+      false
+    else
+      throw :abort
+    end
+  }
 end
 
 class ParentModel < ActiveRecord::Base


### PR DESCRIPTION
paranoia destroys associations even if the destruction is aborted.
My expectation is what associations are not destroyed as the same as ActiveRecord's default.

@radar 
How do you think about this behavior?

----

I added reproduction code as failing tests.
Here is the result of this test cases.
``` console
$ RAILS='~> 6.1' bundle exec rake
Run options: --seed 21553

# Running:

...............F

Failure:
ParanoiaTest#test_destroy_behavior_for_association_with_abort [test/paranoia_test.rb:146]:
Expected: 0
  Actual: 1


rails test test/paranoia_test.rb:135

....................................F

Failure:
ParanoiaTest#test_destroy_bang_behavior_for_association_with_abort [test/paranoia_test.rb:161]:
Expected: 0
  Actual: 1


rails test test/paranoia_test.rb:149

..............................

Finished in 0.542657s, 152.9511 runs/s, 475.4384 assertions/s.
83 runs, 258 assertions, 2 failures, 0 errors, 0 skips
```