### PR TITLE
CI against Ruby 3.0 and 3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          # - 3.0 # incompatible with rubysl
+          - '3.0'
           - 2.7
           - 2.6
           - 2.5
@@ -41,9 +41,9 @@ jobs:
           ruby: 2.5
         # Legacy Rails with newer rubies
         - rails: '~> 5.1.0'
-          ruby: 3.0
+          ruby: '3.0'
         - rails: '~> 5.2.0'
-          ruby: 3.0
+          ruby: '3.0'
 
     env:
       RAILS: ${{ matrix.rails }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - 3.1
           - '3.0'
           - 2.7
           - 2.6
@@ -44,6 +45,10 @@ jobs:
           ruby: '3.0'
         - rails: '~> 5.2.0'
           ruby: '3.0'
+        - rails: '~> 5.1.0'
+          ruby: 3.1
+        - rails: '~> 5.2.0'
+          ruby: 3.1
 
     env:
       RAILS: ${{ matrix.rails }}

--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,12 @@ platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'
 end
 
-platforms :rbx do
-  gem 'rubinius-developer_tools'
-  gem 'rubysl', '~> 2.0'
-  gem 'rubysl-test-unit'
+if RUBY_ENGINE == 'rbx'
+  platforms :rbx do
+    gem 'rubinius-developer_tools'
+    gem 'rubysl', '~> 2.0'
+    gem 'rubysl-test-unit'
+  end
 end
 
 rails = ENV['RAILS'] || '~> 5.2.0'


### PR DESCRIPTION
This PR adds Ruby 3.0 and 3.1 to the CI matrix, and does the following:

* Install gems for rbx platform only when running rbx.
  * Otherwise, bundle install fails on Ruby 3 because rubysl ~> 2.0 doesn't support Ruby 3.
  * This is based on kaminari/kaminari@59dbc12.