### PR TITLE
Define rspec matcher only when rspec is defined

### DIFF
--- a/lib/paranoia/rspec.rb
+++ b/lib/paranoia/rspec.rb
@@ -1,4 +1,4 @@
-if Rails.env.test?
+if defined?(RSpec)
   require 'rspec/expectations'
 
   # Validate the subject's class did call "acts_as_paranoid"


### PR DESCRIPTION
Our CI tests run in a `CI` environment, so the rspec matcher is not defined. This PR changes the definition of the matcher so it is always defined when RSpec itself is defined.

Added no tests because not really possible. The gem itself does not use RSpec for tests.