### PR TITLE
skip updating paranoia_destroy_attributes for records while really_destroy!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # paranoia Changelog
 
+## 2.6.1
+
+* [#535](https://github.com/rubysherpas/paranoia/pull/535) Allow to skip updating paranoia_destroy_attributes for records while really_destroy!
+  [Anton Bogdanov](https://github.com/kortirso)
+
 ## 2.6.0
 
 * [#512](https://github.com/rubysherpas/paranoia/pull/512) Quote table names; Mysql 8 has keywords that might match table names which cause an exception.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Gem Version](https://badge.fury.io/rb/paranoia.svg)](https://badge.fury.io/rb/paranoia)
 [![build](https://github.com/rubysherpas/paranoia/actions/workflows/build.yml/badge.svg)](https://github.com/rubysherpas/paranoia/actions/workflows/build.yml)
 
-**Notice:** 
+**Notice:**
 
 `paranoia` has some surprising behaviour (like overriding ActiveRecord's `delete` and `destroy`) and is not recommended for new projects. See [`discard`'s README](https://github.com/jhawthorn/discard#why-not-paranoia-or-acts_as_paranoid) for more details.
 
@@ -100,6 +100,14 @@ If you really want it gone *gone*, call `really_destroy!`:
 >> client.deleted_at
 # => nil
 >> client.really_destroy!
+# => client
+```
+
+If you need skip updating timestamps for deleting records, call `really_destroy!(update_destroy_attributes: false)`.
+When we call `really_destroy!(update_destroy_attributes: false)` on the parent `client`, then each child `email` will also have `really_destroy!(update_destroy_attributes: false)` called.
+
+``` ruby
+>> client.really_destroy!(update_destroy_attributes: false)
 # => client
 ```
 

--- a/lib/paranoia/version.rb
+++ b/lib/paranoia/version.rb
@@ -1,3 +1,3 @@
 module Paranoia
-  VERSION = '2.6.0'.freeze
+  VERSION = '2.6.1'.freeze
 end


### PR DESCRIPTION
There is issue with destroying records when, for example:
- record had nil attribute, or optional belongs_to (database didn't have not null constaint)
- record was soft-deleted
- some validation was added, or belongs_to was changed to required state
- calling `record.really_destroy!` will fail during `update_columns`, because record can't be saved with some nil values

and there is some additional profit, `really_destroy!` will work faster without updating timestamps