### PR TITLE
Remove unused local variable and move local variables into conditional branch

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -219,12 +219,9 @@ module Paranoia
         association_class = association.klass
         if association_class.paranoid?
           association_foreign_key = association.options[:through].present? ? association.klass.primary_key : association.foreign_key
-          association_find_conditions = if association.type
-                                          association_polymorphic_type = association.type
-                                          { association_polymorphic_type => self.class.name.to_s, association_foreign_key => self.id }
-                                        else
-                                          { association_foreign_key => self.id }
-                                        end
+          association_find_conditions = { association_foreign_key => self.id }
+          association_find_conditions[association.type] = self.class.name if association.type
+
           association_class.only_deleted.where(association_find_conditions).first
             .try!(:restore, recursive: true, :recovery_window_range => recovery_window_range)
         end

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -216,7 +216,6 @@ module Paranoia
       end
 
       if association_data.nil? && association.macro.to_s == "has_one"
-        association_class_name = association.klass.name
 
         association_foreign_key = if association.options[:through].present?
           association.klass.primary_key

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -216,22 +216,15 @@ module Paranoia
       end
 
       if association_data.nil? && association.macro.to_s == "has_one"
-
-        association_foreign_key = if association.options[:through].present?
-          association.klass.primary_key
-        else
-          association.foreign_key
-        end
-
-        association_find_conditions = if association.type
-          association_polymorphic_type = association.type
-          { association_polymorphic_type => self.class.name.to_s, association_foreign_key => self.id }
-        else
-          { association_foreign_key => self.id }
-        end
-
         association_class = association.klass
         if association_class.paranoid?
+          association_foreign_key = association.options[:through].present? ? association.klass.primary_key : association.foreign_key
+          association_find_conditions = if association.type
+                                          association_polymorphic_type = association.type
+                                          { association_polymorphic_type => self.class.name.to_s, association_foreign_key => self.id }
+                                        else
+                                          { association_foreign_key => self.id }
+                                        end
           association_class.only_deleted.where(association_find_conditions).first
             .try!(:restore, recursive: true, :recovery_window_range => recovery_window_range)
         end

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -223,11 +223,11 @@ module Paranoia
           association.foreign_key
         end
 
-        if association.type
+        association_find_conditions = if association.type
           association_polymorphic_type = association.type
-          association_find_conditions = { association_polymorphic_type => self.class.name.to_s, association_foreign_key => self.id }
+          { association_polymorphic_type => self.class.name.to_s, association_foreign_key => self.id }
         else
-          association_find_conditions = { association_foreign_key => self.id }
+          { association_foreign_key => self.id }
         end
 
         association_class = association.klass


### PR DESCRIPTION
Found dead code, minor enhancement point and fixed them：
- Removed unused local variable `association_class_name` introduced in commit 9937512664d2338ffe1fe3cd522e84dfbf0cafa6 .
- And relocated local variables referenced solely when `association_class.paranoid?` is true.
- Streamlined local variable assignments, aligning with the pattern used for `association_foreign_key`.
