### PR TITLE
fix: restore has_one with scope

### DIFF
--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -1225,22 +1225,24 @@ class ParanoiaTest < test_framework
   end
 
   def test_has_one_with_scope_missed
-    # this order is important
     parent = ParanoidHasOneWithScope.create
+    gamma = ParanoidHasOneWithScope.create(kind: :gamma, paranoid_has_one_with_scope: parent) # this has to be first
     alpha = ParanoidHasOneWithScope.create(kind: :alpha, paranoid_has_one_with_scope: parent)
     beta = ParanoidHasOneWithScope.create(kind: :beta, paranoid_has_one_with_scope: parent)
 
     parent.destroy
+    assert !gamma.reload.destroyed?
+    gamma.destroy
     assert_equal 0, ParanoidHasOneWithScope.count # all destroyed
     parent.reload # we unload associations
     parent.restore(recursive: true)
 
-    assert_equal "beta", parent.beta&.kind
-    assert_equal "alpha", parent.alpha&.kind
+    assert_equal "alpha", parent.alpha&.kind, "record was not restored"
+    assert_equal "beta", parent.beta&.kind, "record was not restored"
+    assert_nil parent.gamma, "record was incorrectly restored"
   end
 
-  def test_has_one_with_scope_not_destroyed
-    # this order is important
+  def test_has_one_with_scope_not_restored
     parent = ParanoidHasOneWithScope.create
     gamma = ParanoidHasOneWithScope.create(kind: :gamma, paranoid_has_one_with_scope: parent)
     parent.destroy

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -1646,7 +1646,7 @@ end
 
 class ParanoidHasOneWithScope < ActiveRecord::Base
   acts_as_paranoid
-  has_one :left, -> () { where(kind: 'left') }, class_name: "ParanoidHasOneWithScope", dependent: :destroy, inverse_of: :paranoid_has_one_with_scope, foreign_key: :paranoid_has_one_with_scope_id
-  has_one :right, -> () { where(kind: 'right') }, class_name: "ParanoidHasOneWithScope", dependent: :destroy, inverse_of: :paranoid_has_one_with_scope, foreign_key: :paranoid_has_one_with_scope_id
+  has_one :left, -> () { where(kind: 'left') }, class_name: "ParanoidHasOneWithScope", dependent: :destroy
+  has_one :right, -> () { where(kind: 'right') }, class_name: "ParanoidHasOneWithScope", dependent: :destroy
   belongs_to :paranoid_has_one_with_scope
 end


### PR DESCRIPTION
When recursively restoring a has_one relation, Paranoia tries to restore any matching deleted record. It ignores the association scope. This can cause both false positives and false negatives when restoring.

This PR imitates [this commit](https://github.com/ActsAsParanoid/acts_as_paranoid/commit/d6a898e35789089706a8130f706720504a527662) from acts_as_paranoid. I am not sure if intentionally, but that commit introduced scope merging for has_one relations there.

> when looking for parent.alpha (or beta) to restore, loading association fails, because there are no undeleted records
> lib/paranoia.rb:204 `association_data = send(association.name)` = nil
> the procedure at lib/paranoia.rb:224 ignores association scope and restores the lowest-id record, :gamma
> effect: beta was never restored and is nil, gamma was restored incorrectly

I am not sure if `reflection.scope` is the correct way to recover association's scope, acts_as_paranoid does this differently. It works in AR 5.1-7.1 though.
I have tested this PR in ruby 3.2.2 in rails 7.1.3 and 6.1.7.6. It also does work in 5.1.7 application, but I failed to resolve gems in ruby 2.5.8/2.6.9 (and run the suite)