### PR TITLE
Support prebuilt counter cache association list

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -173,8 +173,25 @@ module Paranoia
 
   private
 
+  def counter_cache_disabled?
+    defined?(@_disable_counter_cache) && @_disable_counter_cache
+  end
+
+  def counter_cached_association_names
+    return [] if counter_cache_disabled?
+    super
+  end
+
   def each_counter_cached_associations
-    !(defined?(@_disable_counter_cache) && @_disable_counter_cache) ? super : []
+    return [] if counter_cache_disabled?
+
+    if defined?(super)
+      super
+    else
+      counter_cached_association_names.each do |name|
+        yield association(name)
+      end
+    end
   end
 
   def paranoia_restore_attributes


### PR DESCRIPTION
Fixes https://github.com/rubysherpas/paranoia/issues/552

Rails 7.2 will remove `each_counter_cached_associations` which was the hook to bypass incrementing/decrementing the counter. 
This change overrides the new counter cache list and uses it as the new hook to bypass updating the counter when it is present, else it falls back to the old behavior.