### PR TITLE
Allow Rails 8.0

### DIFF
--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency 'activerecord', '>= 5.1', '< 7.2'
+  s.add_dependency 'activerecord', '>= 5.1', '< 8.1'
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake"


### PR DESCRIPTION
We're unable to test our project with edge Rails at the moment as Paranoia doesn't officially support anything newer than 7.1 and the next version of Rails will be 8.0.

Ran the existing test suite against edge and they all seem to pass.