### PR TITLE
Do not use sqlite3 v2.0.0 or later to fix CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,10 @@ sqlite = ENV['SQLITE_VERSION']
 if sqlite
   gem 'sqlite3', sqlite, platforms: [:ruby]
 else
-  gem 'sqlite3', platforms: [:ruby]
+  # Do not use sqlite3 v2.0.0 or later because it is not compatible with the current Rails version.
+  # We can remove this constraint when Rails 7.2 is released.
+  # See https://github.com/rails/rails/pull/51592 and https://github.com/rails/rails/blob/v7.2.0.rc1/activerecord/CHANGELOG.md#rails-720beta1-may-29-2024
+  gem 'sqlite3', "~> 1.4", platforms: [:ruby]
 end
 
 platforms :jruby do


### PR DESCRIPTION
This PR updates the Gemfile to sqlite3 `~> 1.4` to pass the CI.

### Background

We have failed builds on GitHub Actions because sqlite3 version v2.0.0 was just released, and the current ActiveRecord doesn't support sqlite3 v2.

- ref. 
   - https://rubygems.org/gems/sqlite3/versions
   - https://github.com/rails/rails/pull/51592