### PR TITLE
Add support for Rails 7.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails: ["~> 7.1.0", "~> 7.0.0", "~> 6.1.0", "~> 6.0.0"]
+        rails: ["~> 7.2.0", "~> 7.1.0", "~> 7.0.0", "~> 6.1.0", "~> 6.0.0"]
         ruby: ["3.2.2", "3.1.4", "3.0.6", "2.7.8"]
         include:
           - ruby: 3.2
@@ -39,6 +39,12 @@ jobs:
             rails: '~> 5.2.0'
           - ruby: 2.5
             rails: '~> 5.1.0'
+        exclude:
+          # Rails 7.2.0 requires Ruby 3.1.0 or later
+          - ruby: "3.0.6"
+            rails: "~> 7.2.0"
+          - ruby: "2.7.8"
+            rails: "~> 7.2.0"
         #os: ubuntu-latest
         #arch: x64
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 2.6.4 - July 20, 2024
 
-Add support for [Rails 7.2](https://github.com/rails/rails/releases/tag/v7.2.0)
-
 * [#554](https://github.com/rubysherpas/paranoia/pull/554) Support prebuilt counter cache association list (#554)
   [Joé Dupuis](https://github.com/JoeDupuis)
 * [#551](https://github.com/rubysherpas/paranoia/pull/551) Fix: restore has_one with scope (#551)

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ sqlite = ENV['SQLITE_VERSION']
 if sqlite
   gem 'sqlite3', sqlite, platforms: [:ruby]
 else
-  gem 'sqlite3', platforms: [:ruby]
+  gem 'sqlite3', '~> 1.4', platforms: [:ruby]
 end
 
 platforms :jruby do

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency 'activerecord', '>= 5.1', '< 7.2'
+  s.add_dependency 'activerecord', '>= 5.1', '< 8.0'
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake"


### PR DESCRIPTION
This adds support for Rails 7.2. 

Everything is pretty straightforward with the exception of the required version of `sqlite3`. I see the `SQLITE_VERSION` env var can be used to specify a specific version of sqlite3, so maybe I should use that for testing rails 7.2?

closes #562