### PR TITLE
fix typo in newly added readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ end
 
 #### delete_all:
 
-The gem supports `delete_all` method, however it is disabled by default, to enabled add this in your `environment` file
+The gem supports `delete_all` method, however it is disabled by default, to enable it add this in your `environment` file
 
 ``` ruby
 Paranoia.delete_all_enabled = true


### PR DESCRIPTION
fix typo in the new part I added to the read me in [this](https://github.com/rubysherpas/paranoia/pulls?q=is%3Apr+is%3Aclosed) PR