### PR TITLE
Fix really_destroy used against a has_one relationship that is soft deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # paranoia Changelog
 
+## 3.1.1 - July 14, 2026
+
+- [#574](https://github.com/rubysherpas/paranoia/issues/574) Fix really_destroy used against a has_one relationship that is soft deleted
+
 ## 3.1.0 - November 7, 2025
 
 - [#580](https://github.com/rubysherpas/paranoia/issues/580) Support Rails 8.0 and 8.1

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -182,6 +182,9 @@ module Paranoia
             association_data = self.send(name)
             # has_one association can return nil
             # .paranoid? will work for both instances and classes
+            if association_data.nil? && reflection.has_one? && reflection.klass.paranoid?
+              association_data = reflection.klass.only_deleted.find_by(reflection.foreign_key => self.id)
+            end
             next unless association_data && association_data.paranoid?
             if reflection.collection?
               next association_data.with_deleted.find_each { |record|

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -183,7 +183,9 @@ module Paranoia
             # has_one association can return nil
             # .paranoid? will work for both instances and classes
             if association_data.nil? && reflection.has_one? && reflection.klass.paranoid?
-              association_data = reflection.klass.only_deleted.find_by(reflection.foreign_key => self.id)
+              query = { reflection.foreign_key => self.id }
+              query[reflection.type] = self.class.name if reflection.options[:as] # Handle polymorphic associations
+              association_data = reflection.klass.only_deleted.find_by(query)
             end
             next unless association_data && association_data.paranoid?
             if reflection.collection?

--- a/lib/paranoia/version.rb
+++ b/lib/paranoia/version.rb
@@ -1,3 +1,3 @@
 module Paranoia
-  VERSION = '3.1.0'.freeze
+  VERSION = '3.1.1'.freeze
 end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -1419,6 +1419,16 @@ class ParanoiaTest < test_framework
     assert_equal 2, employer.jobs.with_deleted.count
   end
 
+  def test_really_destroy_against_soft_deleted_object_with_has_one_association
+    model = ParanoidModelWithHasOne.create(paranoid_model_with_belong: ParanoidModelWithBelong.create)
+    assert_equal 1, ParanoidModelWithBelong.with_deleted.count
+    model.destroy
+    assert_equal 1, ParanoidModelWithBelong.with_deleted.count
+    model.reload
+    model.really_destroy!
+    assert_equal 0, ParanoidModelWithBelong.with_deleted.count # I think this should fail.
+  end
+
   private
   def get_featureful_model
     FeaturefulModel.new(:name => "not empty")

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -1426,7 +1426,21 @@ class ParanoiaTest < test_framework
     assert_equal 1, ParanoidModelWithBelong.with_deleted.count
     model.reload
     model.really_destroy!
-    assert_equal 0, ParanoidModelWithBelong.with_deleted.count # I think this should fail.
+    assert_equal 0, ParanoidModelWithBelong.with_deleted.count
+  end
+
+  def test_really_destroy_against_soft_deleted_object_with_polymorphic_has_one_association
+    unrelated_model = PolymorphicModel.create(parent_id: 1, parent_type: 'AModel')
+    model = ParentModel.create(id: 1, polymorphic_model: PolymorphicModel.create)
+    unrelated_model.destroy # means that later on in the test, there will be 2 deleted polymorphic models with parent_id of 1
+    
+    assert_equal 2, PolymorphicModel.with_deleted.count
+    model.destroy
+    assert_equal 2, PolymorphicModel.with_deleted.count
+    model.reload
+    model.really_destroy!
+    assert_equal 1, PolymorphicModel.with_deleted.count
+    assert_equal 'AModel', PolymorphicModel.with_deleted.first.parent_type
   end
 
   private


### PR DESCRIPTION
I found a bug. The test explains the scenario but I'll explain it here as well.

Given:
```ruby
class MyModel < ActiveRecord::Base
  acts_as_paranoid
  has_one: linked_model, dependant: destroy
end

class LinkedModel < ActiveRecord::Base
  acts_as_paranoid
end

my_model = MyModel.create!(linked_model: LinkedModel.new)
```

- ✅ If you run `my_model.destroy` then both objects get soft-deleted as you would expect
- ❌ However if you then subsequently run `my_model.really_destroy` it does not destroy the associated `linked_model`.

This is because paranoia tries to access the linked model by running `self.send(name)`. This command will not pick up soft-deleted `has_one` associations (though it works fine for `has_many` associations) so some extra code is required in this scenario.

Note the reload in the test is required, as otherwise the version of `my_model` in memory still links to the `LinkedModel`.