### PR TITLE
chore: fix rails tests on rails versions earlier than 7.1

### DIFF
--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -1,3 +1,4 @@
+require 'logger' # required for test suite to pass on rails versions earlier than 7.1. https://stackoverflow.com/questions/79360526
 require 'bundler/setup'
 require 'active_record'
 require 'minitest/autorun'


### PR DESCRIPTION
The stackoverflow link in the comment talks more about this issue.

Once the repository removes rails versions earlier than 7.1 from the test matrix, this change can be reverted.

See [https://github.com/rubysherpas/paranoia/pull/574 for examples](https://github.com/rubysherpas/paranoia/actions/runs/13175332657/job/37367617499?pr=574) of the test suite failing on older versions.