### PR TITLE
Scope with_deleted's unscope to the model's own table

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ If you want to find only the deleted records:
 Client.only_deleted
 ```
 
+Note that both of them lift the soft-delete scope of *every* paranoid model in the
+relation, not only the one they are called on. See
+[unscope_own_table](#unscope_own_table) to restrict them to a single table.
+
 If you want to check if a record is soft-deleted:
 
 ``` ruby
@@ -375,6 +379,47 @@ class User < ActiveRecord::Base
   acts_as_paranoid(delete_all_enabled: true)
 end
 ```
+
+#### unscope_own_table:
+
+`with_deleted` and `only_deleted` remove the `deleted_at` condition of every table
+of the relation, not just the one of the model they are called on. With a
+`has_many through` association between paranoid models, that also returns the
+records reached through a soft-deleted join model:
+
+``` ruby
+class User < ActiveRecord::Base
+  acts_as_paranoid
+  has_many :posts
+  has_many :comments, through: :posts
+end
+
+# Returns the soft-deleted comments of the user, but also the comments that
+# belong to soft-deleted posts.
+user.comments.with_deleted
+```
+
+Enabling `unscope_own_table` restricts them to the table of the model they are
+called on. It is disabled by default, to enable it add this in your `environment`
+file
+
+``` ruby
+Paranoia.unscope_own_table = true
+```
+alternatively, you can enable/disable it for specific models as follow:
+
+``` ruby
+class Comment < ActiveRecord::Base
+  acts_as_paranoid(unscope_own_table: true)
+end
+
+# Now returns the soft-deleted comments of the user, but still only those
+# belonging to posts that are not soft-deleted.
+user.comments.with_deleted
+```
+
+The option is read from the model `with_deleted` is called on, which is `Comment`
+in the example above, not `User`.
 
 ## Acts As Paranoid Migration
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -10,7 +10,8 @@ module Paranoia
   class << self
     # Change default values in a rails initializer
     attr_accessor :default_sentinel_value,
-                  :delete_all_enabled
+                  :delete_all_enabled,
+                  :unscope_own_table
   end
 
   def self.included(klazz)
@@ -23,6 +24,10 @@ module Paranoia
     # If you want to find all records, even those which are deleted
     def with_deleted
       if ActiveRecord::VERSION::STRING >= "4.1"
+        # Unscoping by column name alone drops the condition from every table of the
+        # relation, lifting the paranoia scope of the other paranoid models joined into
+        # it (e.g. the join model of a `has_many through` association) as well.
+        return unscope where: { table_name => paranoia_column } if paranoia_unscope_own_table
         return unscope where: paranoia_column
       end
       all.tap { |x| x.default_scoped = false }
@@ -184,7 +189,10 @@ module Paranoia
             # .paranoid? will work for both instances and classes
             next unless association_data && association_data.paranoid?
             if reflection.collection?
-              next association_data.with_deleted.find_each { |record|
+              # Hard deleting an association has to reach every record, including the
+              # ones behind a soft-deleted join model, so the paranoia scope is lifted
+              # for the whole relation here, whatever `unscope_own_table` is set to.
+              next association_data.unscope(where: reflection.klass.paranoia_column).find_each { |record|
                 record.really_destroy!(update_destroy_attributes: update_destroy_attributes)
               }
             end
@@ -320,11 +328,12 @@ ActiveSupport.on_load(:active_record) do
 
       include Paranoia
       class_attribute :paranoia_column, :paranoia_sentinel_value, :paranoia_after_restore_commit,
-        :delete_all_enabled
+        :paranoia_unscope_own_table, :delete_all_enabled
 
       self.paranoia_column = (options[:column] || :deleted_at).to_s
       self.paranoia_sentinel_value = options.fetch(:sentinel_value) { Paranoia.default_sentinel_value }
       self.paranoia_after_restore_commit = options.fetch(:after_restore_commit) { false }
+      self.paranoia_unscope_own_table = options.fetch(:unscope_own_table) { Paranoia.unscope_own_table }
       def self.paranoia_scope
         where(paranoia_column => paranoia_sentinel_value)
       end

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -60,6 +60,7 @@ def setup!
     'paranoid_has_one_throughs' => 'paranoid_has_through_restore_parent_id INTEGER NOT NULL, empty_paranoid_model_id INTEGER NOT NULL, deleted_at DATETIME',
     'paranoid_has_many_throughs' => 'paranoid_has_through_restore_parent_id INTEGER NOT NULL, empty_paranoid_model_id INTEGER NOT NULL, deleted_at DATETIME',
     'paranoid_has_one_with_scopes' => 'deleted_at DATETIME, kind STRING, paranoid_has_one_with_scope_id INTEGER',
+    'unscope_own_table_models' => 'deleted_at DATETIME',
   }.each do |table_name, columns_as_sql_string|
     ActiveRecord::Base.connection.execute "CREATE TABLE #{table_name} (id INTEGER NOT NULL PRIMARY KEY, #{columns_as_sql_string})"
   end
@@ -1419,9 +1420,87 @@ class ParanoiaTest < test_framework
     assert_equal 2, employer.jobs.with_deleted.count
   end
 
+  def test_with_deleted_only_unscopes_its_own_table_when_unscope_own_table_is_enabled
+    employer = Employer.create
+    kept_employee = Employee.create
+    deleted_employee = Employee.create
+    employee_of_deleted_job = Employee.create
+
+    Job.create :employer => employer, :employee => kept_employee
+    Job.create :employer => employer, :employee => deleted_employee
+    deleted_job = Job.create :employer => employer, :employee => employee_of_deleted_job
+
+    deleted_employee.destroy
+    deleted_job.destroy
+
+    assert_equal [kept_employee.id], employer.employees.pluck(:id).sort
+
+    # Disabled by default, so the paranoia scope of jobs is lifted as well and the
+    # employee behind the deleted job is returned too.
+    assert_equal [kept_employee.id, deleted_employee.id, employee_of_deleted_job.id].sort,
+                 employer.employees.with_deleted.pluck(:id).sort
+
+    with_unscope_own_table(Employee) do
+      assert_equal [kept_employee.id, deleted_employee.id].sort,
+                   employer.employees.with_deleted.pluck(:id).sort
+    end
+  end
+
+  def test_only_deleted_only_unscopes_its_own_table_when_unscope_own_table_is_enabled
+    employer = Employer.create
+    kept_employee = Employee.create
+    deleted_employee = Employee.create
+    deleted_employee_of_deleted_job = Employee.create
+
+    Job.create :employer => employer, :employee => kept_employee
+    Job.create :employer => employer, :employee => deleted_employee
+    deleted_job = Job.create :employer => employer, :employee => deleted_employee_of_deleted_job
+
+    deleted_employee.destroy
+    deleted_employee_of_deleted_job.destroy
+    deleted_job.destroy
+
+    assert_equal [deleted_employee.id, deleted_employee_of_deleted_job.id].sort,
+                 employer.employees.only_deleted.pluck(:id).sort
+
+    with_unscope_own_table(Employee) do
+      assert_equal [deleted_employee.id], employer.employees.only_deleted.pluck(:id).sort
+    end
+  end
+
+  def test_really_destroy_reaches_records_behind_a_soft_deleted_join_model
+    employer = Employer.create
+    employee = Employee.create
+    Job.create(:employer => employer, :employee => employee).destroy
+
+    with_unscope_own_table(Employee) do
+      employer.really_destroy!
+    end
+
+    # `really_destroy!` must not leave the employee behind, no matter how
+    # `with_deleted` is configured.
+    assert_equal 0, Employee.unscoped.where(id: employee.id).count
+  end
+
+  def test_unscope_own_table_disabled_by_default
+    assert_nil ParanoidModel.paranoia_unscope_own_table
+  end
+
+  def test_unscope_own_table_can_be_enabled_per_model
+    assert UnscopeOwnTableModel.paranoia_unscope_own_table
+  end
+
   private
   def get_featureful_model
     FeaturefulModel.new(:name => "not empty")
+  end
+
+  def with_unscope_own_table(klass)
+    previous = klass.paranoia_unscope_own_table
+    klass.paranoia_unscope_own_table = true
+    yield
+  ensure
+    klass.paranoia_unscope_own_table = previous
   end
 end
 
@@ -1872,4 +1951,8 @@ class ParanoidHasOneWithScope < ActiveRecord::Base
   has_one :beta, -> () { where(kind: :beta) }, class_name: "ParanoidHasOneWithScope", dependent: :destroy
   has_one :gamma, -> () { where(kind: :gamma) }, class_name: "ParanoidHasOneWithScope"
   belongs_to :paranoid_has_one_with_scope
+end
+
+class UnscopeOwnTableModel < ActiveRecord::Base
+  acts_as_paranoid unscope_own_table: true
 end


### PR DESCRIPTION
### Goal

`with_deleted` and `only_deleted` remove the paranoia scope of *every* table of the
relation, not only the one of the model they are called on.

```ruby
class User < ActiveRecord::Base
  acts_as_paranoid
  has_many :posts
  has_many :comments, through: :posts
end
```

`user.comments` filters on `comments.deleted_at` and `posts.deleted_at`. Since
`with_deleted` calls `unscope(where: paranoia_column)` and a bare column name is not
bound to a table, Rails drops both conditions, so `user.comments.with_deleted` also
returns the comments of soft-deleted posts:

```sql
-- user.comments.with_deleted
SELECT comments.* FROM comments
INNER JOIN posts ON comments.post_id = posts.id
WHERE posts.user_id = 1
```

Scoping the unscope with the table name keeps `posts.deleted_at IS NULL` in place:

```ruby
unscope(where: { table_name => paranoia_column })
```

This matches the existing note in `only_deleted` that "scoping with the table_name is
mandatory to avoid ambiguous errors when joining tables".

Relations built with `joins` / `eager_load` were never affected, since there the
paranoia scope of the associated model is emitted in the `ON` clause, which
`unscope(where:)` does not touch.

### Backwards compatibility

This changes what existing queries return, so the new behaviour is wrapped in a
setting, following the pattern introduced in #566 for `delete_all`. It is disabled by
default, so this change won't affect existing users.

Enabled globally using

```ruby
Paranoia.unscope_own_table = true
```

Or for specific models

```ruby
acts_as_paranoid(unscope_own_table: true)
```

The option is read from the model `with_deleted` is called on, which is `Comment`
above, not `User`. `only_deleted` is built on `with_deleted` and follows the same
setting.

`really_destroy!` used `with_deleted` to collect the records of a `dependent: :destroy`
collection. Hard deleting has to reach every record, including the ones behind a
soft-deleted join model, so it now lifts the paranoia scope of the whole relation
explicitly and ignores the setting. Without this, enabling the option would leave
those records behind.

Happy to rework this if you would rather make it the default in a major release, or
prefer a different name for the option.

### Testing

`with_deleted` and `only_deleted` are covered with the setting both disabled (current
behaviour) and enabled, plus `really_destroy!` reaching the records behind a
soft-deleted join model. All tests pass on Rails 7.0, 7.1, 7.2, 8.0 and 8.1.

Fixes [Issue#534](https://github.com/rubysherpas/paranoia/issues/534)
